### PR TITLE
VTE fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ this dependencies are included in the install scripts for apt distros and arch
 * wal
 * urxvt or xterm for it to work on your terminal colors without the need of optional configs
 
-**_Attention:_** If you're using another terminals, you can load colors upon opening terminals
-by running `(wpg -t)` in your terminal, you can add this to your terminal's settings or anywhere
-where it allows it to run on startup.
+**_Attention:_** If you're using another terminal, you can load the colors on terminal startup
+by running `(wpg -t)` in your terminal (if you use gnome-terminal, xfce4-terminal, Termite add `(wpg -V)` instead).  
+You can add this to your terminal's settings, your shell `rc` file or anywhere else 
+that allows you to run commands on startup.
 
 # Installing
 
@@ -87,6 +88,7 @@ the cli:
 $ wpg -l #lists the currently added wallpapers
 $ wpg -c #prints the current wallpaper
 $ wpg -t #apply colorscheme to terminal (equivalent to wal -r)
+$ wpg -V #apply colorscheme to terminal with VTE fix (equivalent to wal -rt)
 $ wpg -z wallpaper #shuffles the given wallpaper's colorscheme
 $ wpg --auto wallpaper #generates fg versions of the first 8 colors of the given wallpaper
 $ wpg -d wallpaper #remove an existing wallpaper

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ this dependencies are included in the install scripts for apt distros and arch
 * urxvt or xterm for it to work on your terminal colors without the need of optional configs
 
 **_Attention:_** If you're using another terminal, you can load the colors on terminal startup
-by running `(wpg -t)` in your terminal (if you use gnome-terminal, xfce4-terminal, Termite add `(wpg -V)` instead).  
+by running `(wpg -t)` in your terminal (if you use gnome-terminal, xfce4-terminal or Termite add `(wpg -V)` instead).  
 You can add this to your terminal's settings, your shell `rc` file or anywhere else 
 that allows you to run commands on startup.
 

--- a/wpg
+++ b/wpg
@@ -46,10 +46,11 @@ if __name__ == "__main__":
 
     if args.list:
         show_wallpapers()
-    if args.tty and args.vte:
-        call(['wal','-r','-t'])
-    elif args.tty:
-        call(['wal,'-r'])
+    if args.tty:
+        if args.vte:
+            call(['wal','-r','-t'])
+        else:
+            call(['wal','-r'])
     if args.version:
         print( 'current version: ' + version )
     if args.delete:

--- a/wpg
+++ b/wpg
@@ -24,6 +24,7 @@ if __name__ == "__main__":
     parser.add_argument('--auto','-e', help='auto adjusts the given colorschemes', nargs='*')
     parser.add_argument('--shuffle','-z', help='shuffles the given colorschemes', nargs='*')
     parser.add_argument('--tty','-t', help='send sequences to terminal equivalent to (wal -r)', action='store_true')
+    parser.add_argument('--vte','-V', help='fix artifacts in VTE terminals (Termite, xfce4-terminal, gnome-terminal)', action='store_true')
     args = parser.parse_args()
     if len(sys.argv) < 2:
         run()
@@ -45,8 +46,10 @@ if __name__ == "__main__":
 
     if args.list:
         show_wallpapers()
-    if args.tty:
-        call(['wal','-r'])
+    if args.tty and args.vte:
+        call(['wal','-r','-t'])
+    elif args.tty:
+        call(['wal,'-r'])
     if args.version:
         print( 'current version: ' + version )
     if args.delete:
@@ -67,4 +70,3 @@ if __name__ == "__main__":
             shuffle_colors(arg)
             auto_adjust_colors(arg, CONFIG)
             print('OK:: shuffled {}'.format(arg))
-


### PR DESCRIPTION
`wal` outputs garbage on VTE terminals unless started with the `-t` option, I added an alternative to `wpg -t` for VTE terminals (`wpg -V`) 