### PR TITLE
sample.py: Use 'pywal' function instead.

### DIFF
--- a/wpgtk/data/sample.py
+++ b/wpgtk/data/sample.py
@@ -5,15 +5,8 @@ try:
     import Image
 except ImportError:
     from PIL import Image
-
-
-def hex_color_to_rgb(color):
-    color = color[1:] if color[0] == "#" else color
-    return (
-        int(color[:2], 16),
-        int(color[2:4], 16),
-        int(color[4:], 16)
-        )
+    
+import pywal
 
 
 def create_sample(colors, f=os.path.join(config.WALL_DIR, ".tmp.sample.png")):
@@ -25,5 +18,5 @@ def create_sample(colors, f=os.path.join(config.WALL_DIR, ".tmp.sample.png")):
     for i, c in enumerate(colors):
         for j in range(width_sample*i, width_sample*i+width_sample):
             for k in range(0, 100):
-                pix[j, k] = hex_color_to_rgb(c)
+                pix[j, k] = pywal.util.hex_to_rgb(c)
     im.save(f)


### PR DESCRIPTION
`pywal` exposes some color manipulating functions through the `util` module. 


Code from `pywal`:

```py
def hex_to_rgb(color):
    """Convert a hex color to rgb.""" 
    return tuple(bytes.fromhex(color.strip("#")))
```