### PR TITLE
setup.py: Don't hardcode version number.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 """wpgtk - setup.py"""
-import setuptools
 import os
-import shutil
+import setuptools
 
 try:
     import wpgtk
@@ -17,7 +16,7 @@ except(IOError, ImportError, RuntimeError):
     LONG_DESC = open('README.md').read()
 
 
-VERSION = "4.5"
+VERSION = wpgtk.__version__
 DOWNLOAD = "https://github.com/dylanaraps/pywal/archive/%s.tar.gz" % VERSION
 WALL_DIR = os.path.expanduser('~') + '/.wallpapers'
 

--- a/wpgtk/__init__.py
+++ b/wpgtk/__init__.py
@@ -1,0 +1,8 @@
+"""
+wpgtk: An easy to use, colorscheme generator and wallpaper manager.
+"""
+from .data.config import __version__
+
+__all__ = [
+    "__version__",
+]

--- a/wpgtk/data/config.py
+++ b/wpgtk/data/config.py
@@ -62,21 +62,22 @@ class Config():
             self.options.write(config_file)
 
 
-try:
-    if not os.path.isdir(SCHEME_DIR):
-        print('INF:: Creating dirs...')
-        os.makedirs(XRES_DIR, exist_ok=True)
-        os.makedirs(SAMPLE_DIR, exist_ok=True)
-        os.makedirs(SCHEME_DIR, exist_ok=True)
-        os.makedirs(OPT_DIR, exist_ok=True)
+if __name__ == "__main__":
+    try:
+        if not os.path.isdir(SCHEME_DIR):
+            print('INF:: Creating dirs...')
+            os.makedirs(XRES_DIR, exist_ok=True)
+            os.makedirs(SAMPLE_DIR, exist_ok=True)
+            os.makedirs(SCHEME_DIR, exist_ok=True)
+            os.makedirs(OPT_DIR, exist_ok=True)
 
-    conf_file = Config(CONF_FILE)
-    wpgtk = conf_file.options['wpgtk']
-    wal = conf_file.options['wal']
-except:
-    print('ERR:: Not a valid config file', file=sys.stderr)
-    print('INF:: Copying default config file')
-    shutil.copy(CONF_BACKUP, CONF_FILE)
-    conf_file = Config(CONF_FILE)
-    wpgtk = conf_file.options['wpgtk']
-    wal = conf_file.options['wal']
+        conf_file = Config(CONF_FILE)
+        wpgtk = conf_file.options['wpgtk']
+        wal = conf_file.options['wal']
+    except:
+        print('ERR:: Not a valid config file', file=sys.stderr)
+        print('INF:: Copying default config file')
+        shutil.copy(CONF_BACKUP, CONF_FILE)
+        conf_file = Config(CONF_FILE)
+        wpgtk = conf_file.options['wpgtk']
+        wal = conf_file.options['wal']


### PR DESCRIPTION
This makes it easier to create new releases since there's only one number to increment. 

- Removes unused `shutil` import from `setup.py`.
- Exposes `__version__` to `setup.py`.