### PR TITLE
Improving custom template system (previously Optional files)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,16 @@ with default themes for GTK2, GTK+, openbox and Tint2, that uses
 you can choose to interact with it in two ways, manage your themes 
 from either a cli application or using a GUI.
 
-#### [GUI](https://gfycat.com/DefinitiveSpiffyJohndory)
+### Features
 
-#### [Powerful command line interface](https://gfycat.com/NeighboringSarcasticEquine)
+* #### [GUI](https://gfycat.com/RigidAnxiousElk)
+
+* #### [Powerful command line interface](https://gfycat.com/NeighboringSarcasticEquine)
+
+* #### [Templates](https://gfycat.com/VacantHeavyAmericansaddlebred)
 
 
-![interface_image](http://i.imgur.com/aWgqJPG.png)
+![interface_image](http://i.imgur.com/2cquXzm.png)
 
 
 
@@ -55,15 +59,16 @@ after you install `wpg` you can run `wpg-install.sh`:
   Options:
   -h|help       Display this message
   -v|version    Display script version
-  -o|openbox    Install openbox themes
-  -t|tint2      Install tint2 theme
-  -g|gtk        Install gtk theme
-  -i|icons      Install icon-set
+  -o            Install openbox template
+  -t            Install tint2 template
+  -g            Install gtk theme
+  -r            Install rofi template
+  -i            Install icon-set
   ```
 
 This will install all themes:
   ```
-$ wpg-install.sh -otgi 
+$ wpg-install.sh -otgir
 ```
 
 And if everything went fine you can now execute `wpg` and it will take
@@ -112,12 +117,17 @@ as:
 * xres files under `$HOME/.wallpapers/xres/{image_name}.Xres`
 * environment variables under `$HOME/.wallpapers/current.sh` 
 
-### Templates
+### Configuration
 
-You can add config files for which `wpgtk` will create a copy and
-add a modifiable `template` file to the `~/.themes/color_other` under the file extension `.base`
-in which some keywords will be read and replaced in the original with the respective colors
-matching those keywords, these keywords are:
+The configuration file should be located at `$HOME/.wallpapers/wpg.conf`
+There you can edit settings without the use of the gui.
+
+# Templates
+
+You can add text files for which `wpgtk` will create a copy and a backup and
+add a modifiable `template` file to `~/.themes/color_other` with file extension `.base`
+in this files some keywords will be searched and replaced with the respective hexcodematching those keywords, 
+an thenm replace the original configuration keeping it in sync with the colorscheme, these keywords are:
 
 ```
 #COLOR0 #COLORX10
@@ -133,15 +143,18 @@ matching those keywords, these keywords are:
 
 #COLORIN (active color)
 #COLORACT (inactive color)
+
+wpgtk-ignore: by placing this keyword on the first line of a basefile,
+it will be temporarily disabled, leaving you with the last theme you chose.
 ```
 
-##### Example
-I added a file called `rofi.txt` and wpgtk created a template under `~/.themes/color_other/rofi.sh.base` 
+#### Example
+I added a file called `rofi.txt` and wpgtk created a template under `~/.themes/color_other/rofi.txt.base` 
 in which I can put keywords that will later be replaced when I change colorschemes with `wpgtk` in the
 original file, giving me a dynamic file that changes with my colorscheme.
 
 ```
-# location: ~/.themes/color_other/rofi.sh.base
+# location: ~/.themes/color_other/rofi.txt.base
 
 color-window "#COLOR0, #COLOR0, #COLOR0"
 color-normal "#COLOR0, white, #COLOR0, #COLORACT, white"
@@ -151,17 +164,26 @@ color-active "#COLOR0, #COLORACT, #COLOR0, #COLORACT, white"
 This is the result after applying a colorscheme:
 
 ```
-# location: ~/Code/scripts/rofi.sh
+# location: ~/Code/scripts/rofi.txt
 
 color-window "#22231D, #22231D, #22231D"
 color-normal "#22231D, white, #22231D, #4c837b, white"
 color-active "#22231D, #4c837b, #22231D, #4c837b, white"
 ```
 
-### Configuration
 
-The configuration file should be located at `$HOME/.wallpapers/wpg.conf`
-There you can edit settings without the use of the gui.
+### Restoring old templates
+
+You can also re-add old templates you archive, to do this, you must use the cli and execute the following
+command:
+
+```
+$ wpg -y /path/to/config-file /path/to/saved-base-file
+```
+
+This will reconnect the base file template to the original configuration file and keep it in sync again
+with the colorscheme.
+
 
 # Loading at Startup
 to load your new wallpaper at startup along with the colors add the following to your 

--- a/README.md
+++ b/README.md
@@ -103,20 +103,20 @@ as:
 * xres files under `$HOME/.wallpapers/xres/{image_name}.Xres`
 * environment variables under `$HOME/.wallpapers/current.sh` 
 
-### Optional files
+### Templates
 
-Using the GUI you can add optional files for which `wpgtk` will create a copy and
-add a modifiable file to the `~/.themes/color_other` under the file extension `.base`
-in which some keywords will be replaced with the respective colors matching 
-those keywords, these keywords are:
+Using the GUI you can add config files for which `wpgtk` will create a copy and
+add a modifiable `template` file to the `~/.themes/color_other` under the file extension `.base`
+in which some keywords will be read and replaced in the original with the respective colors
+matching those keywords, these keywords are:
 
-```assembly
+```
 from color 0 to color 9
 #COLORY
 where Y is the number of color
 
 from color 10 to 15
-#COLORXYY 
+#COLORXY
 where Y is the number of color desired
 
 also
@@ -124,7 +124,40 @@ also
 #COLORACT (inactive color)
 ```
 
-after doing this `wpgtk` will replace this new file with the original.
+##### Example
+I added a script called `rofi.sh` and wpgtk created a copy under `~/.themes/color_other/rofi.sh.base` 
+in which I can put keywords that will later be replaced when I change colorschemes with `wpgtk` in the
+original file.
+
+```
+# location: ~/.themes/color_other/rofi.sh.base
+
+rofi -color-window "#COLOR0, #COLOR0, #COLOR0" \
+	-color-normal "#COLOR0, white, #COLOR0, #COLORACT, white" \
+	-color-active "#COLOR0, #COLORACT, #COLOR0, #COLORACT, white" \
+	-tokenize \
+	-hide-scrollbar \
+	-lines 10 \
+	-width 600 \
+	-font "Droid sans mono 8" \
+	-show $1
+```
+
+This is the result after applying a colorscheme:
+
+```
+# location: ~/Code/scripts/rofi.sh
+
+rofi -color-window "#22231D, #22231D, #22231D" \
+	-color-normal "#22231D, white, #22231D, #4c837b, white" \
+	-color-active "#22231D, #4c837b, #22231D, #4c837b, white" \
+	-tokenize \
+	-hide-scrollbar \
+	-lines 10 \
+	-width 600 \
+	-font "Droid sans mono 8" \
+	-show $1
+```
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ from either a cli application or using a GUI.
 * pywal
 
 **_Attention:_** If you're using another terminal, you can load the colors on terminal startup
-by running `(wpg -t &)` in your terminal (if you use gnome-terminal, xfce4-terminal or Termite add `(wpg -V &)` instead).  
+by running `(wpg -t &)` in your terminal.  
 You can add this to your terminal's settings, your shell `rc` file or anywhere else 
 that allows you to run commands on startup.
 
@@ -80,17 +80,27 @@ $ wpg -h
 
 ### General Usage
 
-this is a list of useful wpg commands that you will be using if you want to use
-the cli:
 ```
-$ wpg -l #lists the currently added wallpapers
-$ wpg -c #prints the current wallpaper
-$ wpg -t #apply colorscheme to terminal (equivalent to wal -r)
-$ wpg -z {wallpaper} #shuffles the given wallpaper's colorscheme
-$ wpg --auto {wallpaper} #generates fg versions of the first 8 colors of the given wallpaper
-$ wpg -d {wallpaper} #remove an existing wallpaper
-$ wpg -h #display usage
-$ wpg -s {wallpaper1} [{wallpaper2}] #sets the current wallpaper and colorscheme, wallpaper2 is optional
+usage: wpg [-h] [-s [S [S ...]]] [-r] [-m] [-a [A [A ...]]] [-l]
+                   [--version] [-d [D [D ...]]] [-c] [-e [E [E ...]]]
+                   [-z [Z [Z ...]]] [-t] [-x] [-y [Y [Y ...]]]
+
+optional arguments:
+  -h, --help      show this help message and exit
+  -s [S [S ...]]  set the wallpaper and colorscheme, apply changes system-wide
+  -r              restore the wallpaper and colorscheme
+  -m              pick a random wallpaper and set it
+  -a [A [A ...]]  add images to the wallpaper folder and generate colorschemes
+  -l              see which wallpapers are available
+  --version, -v   print the current version
+  -d [D [D ...]]  delete the wallpaper(s) from wallpaper folder
+  -c              shows the current wallpaper
+  -e [E [E ...]]  auto adjusts the given colorscheme(s)
+  -z [Z [Z ...]]  shuffles the given colorscheme(s)
+  -t              send color sequences to all terminals
+  -x              add, remove and list templates instead of themes
+  -y [Y [Y ...]]  add an existent basefile template
+
 ```
 
 Files exported when creating a theme are all under the same directory `$HOME/.wallpapers`
@@ -104,42 +114,38 @@ as:
 
 ### Templates
 
-Using the GUI you can add config files for which `wpgtk` will create a copy and
+You can add config files for which `wpgtk` will create a copy and
 add a modifiable `template` file to the `~/.themes/color_other` under the file extension `.base`
 in which some keywords will be read and replaced in the original with the respective colors
 matching those keywords, these keywords are:
 
 ```
-from color 0 to color 9
-#COLORY
-where Y is the number of color
+#COLOR0 #COLORX10
+#COLOR1 #COLORX11
+#COLOR2 #COLORX12
+#COLOR3 #COLORX13
+#COLOR4 #COLORX14
+#COLOR5 #COLORX15
+#COLOR6
+#COLOR7
+#COLOR8
+#COLOR9
 
-from color 10 to 15
-#COLORXY
-where Y is the number of color desired
-
-also
 #COLORIN (active color)
 #COLORACT (inactive color)
 ```
 
 ##### Example
-I added a script called `rofi.sh` and wpgtk created a copy under `~/.themes/color_other/rofi.sh.base` 
+I added a file called `rofi.txt` and wpgtk created a template under `~/.themes/color_other/rofi.sh.base` 
 in which I can put keywords that will later be replaced when I change colorschemes with `wpgtk` in the
-original file.
+original file, giving me a dynamic file that changes with my colorscheme.
 
 ```
 # location: ~/.themes/color_other/rofi.sh.base
 
-rofi -color-window "#COLOR0, #COLOR0, #COLOR0" \
-	-color-normal "#COLOR0, white, #COLOR0, #COLORACT, white" \
-	-color-active "#COLOR0, #COLORACT, #COLOR0, #COLORACT, white" \
-	-tokenize \
-	-hide-scrollbar \
-	-lines 10 \
-	-width 600 \
-	-font "Droid sans mono 8" \
-	-show $1
+color-window "#COLOR0, #COLOR0, #COLOR0"
+color-normal "#COLOR0, white, #COLOR0, #COLORACT, white"
+color-active "#COLOR0, #COLORACT, #COLOR0, #COLORACT, white"
 ```
 
 This is the result after applying a colorscheme:
@@ -147,15 +153,9 @@ This is the result after applying a colorscheme:
 ```
 # location: ~/Code/scripts/rofi.sh
 
-rofi -color-window "#22231D, #22231D, #22231D" \
-	-color-normal "#22231D, white, #22231D, #4c837b, white" \
-	-color-active "#22231D, #4c837b, #22231D, #4c837b, white" \
-	-tokenize \
-	-hide-scrollbar \
-	-lines 10 \
-	-width 600 \
-	-font "Droid sans mono 8" \
-	-show $1
+color-window "#22231D, #22231D, #22231D"
+color-normal "#22231D, white, #22231D, #4c837b, white"
+color-active "#22231D, #4c837b, #22231D, #4c837b, white"
 ```
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -59,12 +59,11 @@ after you install `wpg` you can run `wpg-install.sh`:
   -t|tint2      Install tint2 theme
   -g|gtk        Install gtk theme
   -i|icons      Install icon-set
-  -a|all        Install all themes
   ```
 
 This will install all themes:
   ```
-$ wpg-install.sh -a 
+$ wpg-install.sh -otgi 
 ```
 
 And if everything went fine you can now execute `wpg` and it will take

--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import sys
-import os
 import random
 import wpgtk.data.config as config
 from wpgtk.data import files, themer
@@ -16,43 +15,47 @@ import pywal
 def main():
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('--set', '-s',
+    parser.add_argument('-s',
                         help='set the wallpaper and colorscheme, apply \
                         changes system-wide',
                         nargs='*')
-    parser.add_argument('--restore', '-r',
+    parser.add_argument('-r',
                         help='restore the wallpaper and colorscheme',
                         action='store_true')
-    parser.add_argument('--random', '-m',
+    parser.add_argument('-m',
                         help='pick a random wallpaper and set it',
                         action='store_true')
-    parser.add_argument('--add', '-a',
+    parser.add_argument('-a',
                         help='add images to the wallpaper folder and generate \
                         colorschemes',
                         nargs='*')
-    parser.add_argument('--list', '-l',
+    parser.add_argument('-l',
                         help='see which wallpapers are available',
                         action='store_true')
     parser.add_argument('--version', '-v',
                         help='print the current version',
                         action='store_true')
-    parser.add_argument('--delete', '-d',
+    parser.add_argument('-d',
                         help='delete the wallpaper(s) from wallpaper folder',
                         nargs='*')
-    parser.add_argument('--current', '-c',
+    parser.add_argument('-c',
                         help='shows the current wallpaper',
                         action='store_true')
-    parser.add_argument('--auto', '-e',
-                        help='auto adjusts the given colorschemes',
+    parser.add_argument('-e',
+                        help='auto adjusts the given colorscheme(s)',
                         nargs='*')
-    parser.add_argument('--shuffle', '-z',
-                        help='shuffles the given colorschemes',
+    parser.add_argument('-z',
+                        help='shuffles the given colorscheme(s)',
                         nargs='*')
-    parser.add_argument('--tty', '-t',
-                        help='send sequences to terminal equivalent to wal -r',
+    parser.add_argument('-t',
+                        help='send color sequences to all terminals',
                         action='store_true')
-    parser.add_argument('--create-template', '-x',
-                        help='create template(s) from text file(s)',
+    parser.add_argument('-x',
+                        help='add, remove and list \
+                             templates instead of themes',
+                        action='store_true')
+    parser.add_argument('-y',
+                        help='add an existent basefile template',
                         nargs='*')
 
     config.init()
@@ -64,64 +67,68 @@ def main():
         except NameError:
             print('ERR:: missing pygobject module, use cli', file=sys.stderr)
 
-    if args.set:
-        if len(args.set) == 1:
+    if args.s:
+        if len(args.s) == 1:
             try:
-                themer.set_theme(args.set[0],
-                                 args.set[0],
-                                 args.restore)
+                themer.set_theme(args.s[0], args.s[0], args.r)
             except TypeError as e:
-                print('ERR:: file ' + args.set[0] + ' not found')
+                print('ERR:: file ' + args.s[0] + ' not found')
                 raise e
-        elif len(args.set) == 2:
+        elif len(args.s) == 2:
             try:
-                themer.set_theme(args.set[0],
-                                 args.set[1],
-                                 args.restore)
+                themer.set_theme(args.s[0], args.s[1], args.r)
             except TypeError:
                 print('ERR:: file  not found')
-        elif len(args.set) > 2:
+        elif len(args.s) > 2:
             print('ERR:: Specify just 2 filenames')
 
-    if args.list:
-        files.show_files()
+    if args.l:
+        if args.x:
+            templates = files.get_file_list(config.OPT_DIR, False)
+            [print(t) for t in templates if '.base' in t]
+        else:
+            files.show_files()
 
-    if args.tty:
+    if args.t:
         pywal.reload.colors(True, config.WALL_DIR)
 
     if args.version:
         print('current version: ' + __version__)
 
-    if args.delete:
-        for e in args.delete:
-            themer.delete_theme(e)
+    if args.d:
+        for e in args.d:
+            if args.x:
+                files.remove_template(e)
+            else:
+                themer.delete_theme(e)
 
-    if args.current:
+    if args.c:
         themer.show_current()
 
-    if args.add:
-        for e in args.add:
-            themer.create_theme(e)
+    if args.a:
+        if args.x:
+            files.add_template(args.a[0])
+        else:
+            for e in args.a:
+                themer.create_theme(e)
 
-    if args.random:
+    if args.m:
         filename = random.choice(files.get_file_list())
         themer.set_theme(filename, filename)
 
-    if args.auto:
-        for arg in args.auto:
+    if args.e:
+        for arg in args.e:
             themer.auto_adjust_colors(arg)
             print('OK:: Auto-adjusted %s' % arg)
 
-    if args.shuffle:
-        for arg in args.shuffle:
+    if args.z:
+        for arg in args.z:
             themer.shuffle_colors(arg)
             themer.auto_adjust_colors(arg)
             print('OK:: shuffled %s' % arg)
 
-    if args.create_template:
-        for arg in args.create_template:
-            files.connect_conf(os.path.abspath(arg))
-            print('OK:: added %s.base' % arg)
+    if args.y:
+        files.add_template(arg.y[0], arg.y[1])
 
 
 if __name__ == "__main__":

--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -120,7 +120,7 @@ def main():
 
     if args.create_template:
         for arg in args.create_template:
-            themer.connect_conf(os.path.abspath(arg))
+            files.connect_conf(os.path.abspath(arg))
             print('OK:: added %s.base' % arg)
 
 

--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+import os
 import random
 import wpgtk.data.config as config
 from wpgtk.data import files, themer
@@ -50,6 +51,9 @@ def main():
     parser.add_argument('--tty', '-t',
                         help='send sequences to terminal equivalent to wal -r',
                         action='store_true')
+    parser.add_argument('--create-template', '-x',
+                        help='create template(s) from text file(s)',
+                        nargs='*')
 
     config.init()
     args = parser.parse_args()
@@ -113,6 +117,11 @@ def main():
             themer.shuffle_colors(arg)
             themer.auto_adjust_colors(arg)
             print('OK:: shuffled %s' % arg)
+
+    if args.create_template:
+        for arg in args.create_template:
+            themer.connect_conf(os.path.abspath(arg))
+            print('OK:: added %s.base' % arg)
 
 
 if __name__ == "__main__":

--- a/wpgtk/data/config.py
+++ b/wpgtk/data/config.py
@@ -5,7 +5,7 @@ import sys
 
 __version__ = '4.5.8'
 
-conf_file = None
+options = None
 wpgtk = None
 wal = None
 
@@ -32,48 +32,20 @@ FILE_DIC = {'openbox':    os.path.join(HOME, '.themes/colorbamboo/openbox-3/them
             'icon-step2': os.path.join(HOME, '.icons/flattrcolor/scripts/replace_script.sh')}
 
 
-class Config():
-
-    """This class contains the parsed configuration
-       File and is to be a singleton for use in all
-       other modules and classes"""
-
-    class __Config():
-        def __init__(self, config_path):
-            self.config_path = config_path
-            self.options = configparser.ConfigParser()
-            self.options.read(self.config_path)
-
-    options = None
-    instance = None
-
-    # Just parse the configuration once, unless reload_config
-    # Method is called, the configuration file is never refreshed
-
-    def __init__(self, config_path=CONF_FILE):
-        if not self.instance:
-            self.instance = self.__Config(config_path)
-            self.options = self.instance.options
-        elif config_path != self.instance.config_path:
-            self.instance = self.__Config(config_path)
-            self.options = self.instance.options
-
-    def reload_conf(self, config_path=CONF_FILE):
-        self.instance = self.__Config(config_path)
-        self.options = self.instance.options
-
-    def write_conf(self, config_path=CONF_FILE):
-        with open(config_path, 'w') as config_file:
-            self.options.write(config_file)
+def write_conf(config_path=CONF_FILE):
+    global options
+    with open(config_path, 'w') as config_file:
+        options.write(config_file)
 
 
 def load_sections():
-    global conf_file
+    global options
     global wpgtk
     global wal
-    conf_file = Config(CONF_FILE)
-    wpgtk = conf_file.options['wpgtk']
-    wal = conf_file.options['wal']
+    options = configparser.ConfigParser()
+    options.read(CONF_FILE)
+    wpgtk = options['wpgtk']
+    wal = options['wal']
 
 
 def init():

--- a/wpgtk/data/config.py
+++ b/wpgtk/data/config.py
@@ -22,10 +22,7 @@ SCHEME_DIR = os.path.join(WALL_DIR, 'schemes')
 OPT_DIR = os.path.join(HOME, '.themes/color_other')
 
 
-FILE_DIC = {'openbox':    os.path.join(HOME, '.themes/colorbamboo/openbox-3/themerc'),
-            'openbox-nb': os.path.join(HOME, '.themes/colorbamboo-nb/openbox-3/themerc'),
-            'tint2':      os.path.join(HOME, '.config/tint2/tint2rc'),
-            'gtk2':       os.path.join(HOME, '.themes/FlatColor/gtk-2.0/gtkrc'),
+FILE_DIC = {'gtk2':       os.path.join(HOME, '.themes/FlatColor/gtk-2.0/gtkrc'),
             'gtk3.0':     os.path.join(HOME, '.themes/FlatColor/gtk-3.0/gtk.css'),
             'gtk3.20':    os.path.join(HOME, '.themes/FlatColor/gtk-3.20/gtk.css'),
             'icon-step1': os.path.join(HOME, '.icons/flattrcolor/scripts/replace_folder_file.sh'),

--- a/wpgtk/data/config.py
+++ b/wpgtk/data/config.py
@@ -3,7 +3,7 @@ import shutil
 import os
 import sys
 
-__version__ = '4.5.8'
+__version__ = '4.5.9'
 
 options = None
 wpgtk = None

--- a/wpgtk/data/files.py
+++ b/wpgtk/data/files.py
@@ -66,7 +66,7 @@ def add_template(cfile, basefile=None):
 
 def remove_template(basefile):
     basefile_path = os.path.join(config.OPT_DIR, basefile)
-    configfile_path = basefile_path.rstrip('.base')
+    configfile_path = basefile_path.replace('.base', '')
 
     try:
         os.remove(basefile_path)

--- a/wpgtk/data/files.py
+++ b/wpgtk/data/files.py
@@ -1,4 +1,6 @@
 import os
+import shutil
+import sys
 import re
 from . import config
 
@@ -32,3 +34,28 @@ def get_file_list(path=config.WALL_DIR, images=True):
 def show_files(path=config.WALL_DIR, images=True):
     for f in get_file_list(path, images):
         print(f)
+
+
+def connect_conf(filepath):
+
+    # we remove dots from possible dotfiles
+    l = [atom.lstrip('.') for atom in filepath.split('/')
+         if atom is not 'home']
+    if len(l) > 3:
+        l = l[-3::]
+    filename = '.'.join(l)
+    print('ADD::' + filename + '@' + filepath)
+    try:
+        shutil.copy2(filepath, filepath + '.bak')
+        print('::MAKING BACKUP CONFIG')
+        print('::CREATING BASE')
+        shutil.copy2(filepath, os.path.join(config.OPT_DIR,
+                     (filename + '.base')))
+        shutil.copy2(filepath, os.path.join(config.OPT_DIR, filename))
+        os.remove(filepath)
+        os.symlink(os.path.join(config.OPT_DIR, filename), filepath)
+        print('::CREATING SYMLINK')
+    except FileNotFoundError as e:
+        print('ERR::' + str(e.__class__), file=sys.stderr)
+        os.makedirs(config.OPT_DIR)
+        print('INF:: directory created')

--- a/wpgtk/data/files.py
+++ b/wpgtk/data/files.py
@@ -1,7 +1,5 @@
 import os
-import sys
 import re
-import shutil
 from . import config
 
 
@@ -34,25 +32,3 @@ def get_file_list(path=config.WALL_DIR, images=True):
 def show_files(path=config.WALL_DIR, images=True):
     for f in get_file_list(path, images):
         print(f)
-
-
-def connect_conf(filepath):
-    l = filepath.split('/', len(filepath))
-
-    # we remove dots from possible dotfiles
-    filename = l[-2].lstrip('.') + '.' + l[-1].lstrip('.')
-    print('ADD::' + filename + '@' + filepath)
-    try:
-        shutil.copy2(filepath, filepath + '.bak')
-        print('::MAKING BACKUP CONFIG')
-        print('::CREATING BASE')
-        shutil.copy2(filepath, os.path.join(config.OPT_DIR,
-                                            (filename + '.base')))
-        shutil.copy2(filepath, os.path.join(config.OPT_DIR, filename))
-        os.remove(filepath)
-        os.symlink(os.path.join(config.OPT_DIR, filename), filepath)
-        print('::CREATING SYMLINK')
-    except FileNotFoundError as e:
-        print('ERR::' + str(e.__class__), file=sys.stderr)
-        os.makedirs(config.OPT_DIR)
-        print('INF:: directory created')

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -83,9 +83,9 @@ def show_current():
 def shuffle_colors(filename):
     try:
         colors = color.get_color_list(filename)
-        shuffled_colors = colors[1:8]
+        shuffled_colors = colors[1:7]
         shuffle(shuffled_colors)
-        colors = colors[:1] + shuffled_colors + colors[8:]
+        colors = colors[:1] + shuffled_colors + colors[7:]
         sample.create_sample(colors, f=path.join(config.SAMPLE_DIR,
                              filename + '.sample.png'))
         color.write_colors(filename, colors)

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -1,10 +1,9 @@
 import errno
 import pywal
 import shutil
-import sys
 from random import shuffle
 from os.path import realpath
-from os import symlink, remove, path, makedirs
+from os import symlink, remove, path
 from subprocess import Popen, call
 from . import color, sample, config, files
 
@@ -115,25 +114,3 @@ def auto_adjust_colors(filename):
         color.write_colors(filename, color_list)
     except IOError:
         print('ERR:: file not available')
-
-
-def connect_conf(filepath):
-    l = filepath.split('/', len(filepath))
-
-    # we remove dots from possible dotfiles
-    filename = l[-2].lstrip('.') + '.' + l[-1].lstrip('.')
-    print('ADD::' + filename + '@' + filepath)
-    try:
-        shutil.copy2(filepath, filepath + '.bak')
-        print('::MAKING BACKUP CONFIG')
-        print('::CREATING BASE')
-        shutil.copy2(filepath, path.join(config.OPT_DIR,
-                                         (filename + '.base')))
-        shutil.copy2(filepath, path.join(config.OPT_DIR, filename))
-        remove(filepath)
-        symlink(path.join(config.OPT_DIR, filename), filepath)
-        print('::CREATING SYMLINK')
-    except FileNotFoundError as e:
-        print('ERR::' + str(e.__class__), file=sys.stderr)
-        makedirs(config.OPT_DIR)
-        print('INF:: directory created')

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -1,9 +1,10 @@
 import errno
 import pywal
 import shutil
+import sys
 from random import shuffle
 from os.path import realpath
-from os import symlink, remove, path
+from os import symlink, remove, path, makedirs
 from subprocess import Popen, call
 from . import color, sample, config, files
 
@@ -114,3 +115,25 @@ def auto_adjust_colors(filename):
         color.write_colors(filename, color_list)
     except IOError:
         print('ERR:: file not available')
+
+
+def connect_conf(filepath):
+    l = filepath.split('/', len(filepath))
+
+    # we remove dots from possible dotfiles
+    filename = l[-2].lstrip('.') + '.' + l[-1].lstrip('.')
+    print('ADD::' + filename + '@' + filepath)
+    try:
+        shutil.copy2(filepath, filepath + '.bak')
+        print('::MAKING BACKUP CONFIG')
+        print('::CREATING BASE')
+        shutil.copy2(filepath, path.join(config.OPT_DIR,
+                                         (filename + '.base')))
+        shutil.copy2(filepath, path.join(config.OPT_DIR, filename))
+        remove(filepath)
+        symlink(path.join(config.OPT_DIR, filename), filepath)
+        print('::CREATING SYMLINK')
+    except FileNotFoundError as e:
+        print('ERR::' + str(e.__class__), file=sys.stderr)
+        makedirs(config.OPT_DIR)
+        print('INF:: directory created')

--- a/wpgtk/gui/color_grid.py
+++ b/wpgtk/gui/color_grid.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import pywal
 from wpgtk.data import color
 from wpgtk.data import config, files, sample
 from .color_picker import ColorDialog
@@ -8,7 +9,6 @@ from gi import require_version
 from gi.repository import Gtk, Gdk, GdkPixbuf
 require_version("Gtk", "3.0")
 
-import pywal
 
 current_walls = files.get_file_list()
 PAD = 10
@@ -177,9 +177,9 @@ class ColorGrid(Gtk.Grid):
         self.render_sample()
 
     def on_shuffle_click(self, widget):
-        shuffled_colors = self.color_list[1:8]
+        shuffled_colors = self.color_list[1:7]
         shuffle(shuffled_colors)
-        list_tail = shuffled_colors + self.color_list[8:]
+        list_tail = shuffled_colors + self.color_list[7:]
         self.color_list = self.color_list[:1] + list_tail
         self.on_auto_click(widget)
 
@@ -193,7 +193,8 @@ class ColorGrid(Gtk.Grid):
 
         if response == Gtk.ResponseType.OK:
             gcolor = dialog.colorchooser.get_rgba()
-            rgb = list(map(lambda x:round(x*100*2.55), [gcolor.red, gcolor.green, gcolor.blue]))
+            rgb = list(map(lambda x: round(x*100*2.55),
+                           [gcolor.red, gcolor.green, gcolor.blue]))
             hex_color = pywal.util.rgb_to_hex(rgb)
             widget.set_label(hex_color)
             gcolor = Gdk.color_parse(hex_color)
@@ -223,9 +224,8 @@ class ColorGrid(Gtk.Grid):
                                    (selected_file + '.sample.png'))
         self.color_list = color.get_color_list(selected_file)
         self.render_buttons()
-        self.pixbuf_sample = GdkPixbuf.Pixbuf.new_from_file_at_size(sample_path,
-                                                                    width=500,
-                                                                    height=300)
+        self.pixbuf_sample = GdkPixbuf.Pixbuf\
+            .new_from_file_at_size(sample_path, width=500, height=300)
         self.sample.set_from_pixbuf(self.pixbuf_sample)
         if config.wpgtk.getboolean('light_theme'):
             self.color_list = self.color_list[::-1]

--- a/wpgtk/gui/option_grid.py
+++ b/wpgtk/gui/option_grid.py
@@ -134,5 +134,5 @@ class OptionsGrid(Gtk.Grid):
         self.lbl_save.set_text('')
 
     def on_save_button(self,  button):
-        config.conf_file.write_conf()
+        config.write_conf()
         self.lbl_save.set_text('Saved')

--- a/wpgtk/gui/option_grid.py
+++ b/wpgtk/gui/option_grid.py
@@ -54,14 +54,14 @@ class OptionsGrid(Gtk.Grid):
         # Switches
         self.tint2_switch = Gtk.Switch()
         self.tint2_switch.connect('notify::active',  self.on_activate, 'tint2')
-        self.lbl_tint2 = Gtk.Label('Colorize Tint2')
+        self.lbl_tint2 = Gtk.Label('Reload Tint2')
         self.gtk_switch = Gtk.Switch()
         self.gtk_switch.connect('notify::active',  self.on_activate, 'gtk')
         self.lbl_gtk = Gtk.Label('Colorize GTK')
         self.openbox_switch = Gtk.Switch()
         self.openbox_switch.connect('notify::active',
                                     self.on_activate, 'openbox')
-        self.lbl_openbox = Gtk.Label('Colorize openbox')
+        self.lbl_openbox = Gtk.Label('Reload openbox')
 
         # edit cmd
         self.editor_lbl = Gtk.Label('Open optional files with:')

--- a/wpgtk/gui/template_grid.py
+++ b/wpgtk/gui/template_grid.py
@@ -11,7 +11,7 @@ PAD = 10
 icon = 'document-open'
 
 
-class FileGrid(Gtk.Grid):
+class TemplateGrid(Gtk.Grid):
 
     """A helper for choosing config files
     that will be modified with wpgtk's help"""

--- a/wpgtk/gui/template_grid.py
+++ b/wpgtk/gui/template_grid.py
@@ -79,11 +79,10 @@ class TemplateGrid(Gtk.Grid):
         filefilter.add_mime_type("text/*")
         filechooser.add_filter(filefilter)
         response = filechooser.run()
-        response = filechooser.run()
 
         if response == Gtk.ResponseType.OK:
             filepath = filechooser.get_filename()
-            themer.connect_conf(filepath)
+            files.connect_conf(filepath)
             self.item_names = [filen for filen in
                                files.get_file_list(config.OPT_DIR, False)
                                if '.base' in filen]

--- a/wpgtk/gui/template_grid.py
+++ b/wpgtk/gui/template_grid.py
@@ -4,7 +4,7 @@ from gi.repository.GdkPixbuf import Pixbuf
 import os
 from gi import require_version
 from subprocess import Popen
-from wpgtk.data import config, files, themer
+from wpgtk.data import config, files
 require_version("Gtk", "3.0")
 
 PAD = 10
@@ -82,7 +82,7 @@ class TemplateGrid(Gtk.Grid):
 
         if response == Gtk.ResponseType.OK:
             filepath = filechooser.get_filename()
-            files.connect_conf(filepath)
+            files.add_template(filepath)
             self.item_names = [filen for filen in
                                files.get_file_list(config.OPT_DIR, False)
                                if '.base' in filen]
@@ -109,7 +109,7 @@ class TemplateGrid(Gtk.Grid):
     def on_rm_clicked(self, widget):
         if self.current is not None:
             item = self.item_names.pop(self.current)
-            os.remove(os.path.join(config.OPT_DIR, item))
+            files.remove_template(item)
             self.liststore = Gtk.ListStore(Pixbuf, str)
             for filen in self.item_names:
                 pixbuf = Gtk.IconTheme.get_default().load_icon(icon, 64, 0)

--- a/wpgtk/gui/template_grid.py
+++ b/wpgtk/gui/template_grid.py
@@ -4,7 +4,7 @@ from gi.repository.GdkPixbuf import Pixbuf
 import os
 from gi import require_version
 from subprocess import Popen
-from wpgtk.data import config, files
+from wpgtk.data import config, files, themer
 require_version("Gtk", "3.0")
 
 PAD = 10
@@ -83,7 +83,7 @@ class TemplateGrid(Gtk.Grid):
 
         if response == Gtk.ResponseType.OK:
             filepath = filechooser.get_filename()
-            files.connect_conf(filepath)
+            themer.connect_conf(filepath)
             self.item_names = [filen for filen in
                                files.get_file_list(config.OPT_DIR, False)
                                if '.base' in filen]

--- a/wpgtk/gui/theme_picker.py
+++ b/wpgtk/gui/theme_picker.py
@@ -35,7 +35,7 @@ class mainWindow(Gtk.Window):
         self.wpage.set_column_spacing(PAD)
 
         self.cpage = color_grid.ColorGrid(self)
-        self.fpage = base_maker.TemplateGrid(self)
+        self.fpage = template_grid.TemplateGrid(self)
         self.optpage = option_grid.OptionsGrid(self)
 
         self.notebook.append_page(self.wpage, Gtk.Label('Wallpapers'))

--- a/wpgtk/gui/theme_picker.py
+++ b/wpgtk/gui/theme_picker.py
@@ -1,5 +1,5 @@
 from gi import require_version
-from . import color_grid, base_maker, option_grid
+from . import color_grid, template_grid, option_grid
 from wpgtk.data import files, themer, config
 from gi.repository import Gtk, GdkPixbuf
 import os
@@ -35,12 +35,12 @@ class mainWindow(Gtk.Window):
         self.wpage.set_column_spacing(PAD)
 
         self.cpage = color_grid.ColorGrid(self)
-        self.fpage = base_maker.FileGrid(self)
+        self.fpage = base_maker.TemplateGrid(self)
         self.optpage = option_grid.OptionsGrid(self)
 
         self.notebook.append_page(self.wpage, Gtk.Label('Wallpapers'))
         self.notebook.append_page(self.cpage, Gtk.Label('Colors'))
-        self.notebook.append_page(self.fpage, Gtk.Label('Optional Files'))
+        self.notebook.append_page(self.fpage, Gtk.Label('Templates'))
         self.notebook.append_page(self.optpage, Gtk.Label('Options'))
 
         option_list = Gtk.ListStore(str)

--- a/wpgtk/misc/wpg-install.sh
+++ b/wpgtk/misc/wpg-install.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-__ScriptVersion="0.1"
-THEME_DIR="${PWD}/wpgtk-themes"
+__ScriptVersion="0.1.5";
+THEME_DIR="${PWD}/wpgtk-themes";
+COLOR_OTHER="${HOME}/.themes/color_other";
 
 #===  FUNCTION  ================================================================
 #         NAME:  wpg-install
@@ -12,29 +13,39 @@ function usage ()
   echo "Usage :  $0 [options] [--]
 
   Options:
-  -h|help       Display this message
-  -v|version    Display script version
-  -o|openbox    Install openbox themes
-  -t|tint2      Install tint2 theme
-  -g|gtk        Install gtk theme
-  -i|icons      Install icon-set
-  -a|all        Install all themes
+  -h   Display this message
+  -v   Display script version
+  -o   Install openbox themes
+  -t   Install tint2 theme
+  -g   Install gtk theme
+  -i   Install icon-set
+  -r   Install rofi theme
+  -a   Install all themes
   "
 }
 
-function checkgit ()
+function checkprogram ()
 {
-  command -v git >/dev/null 2>&1 || \
-      (echo "Please install git before proceeding" && exit 1);
+  command -v $1 >/dev/null 2>&1;
+  if [[ $? -eq 1 ]]; then
+    echo "Please install $1 before proceeding"; 
+    exit 1;
+  fi
 }
 
 function getfiles ()
 {
-  checkgit;
-  mkdir -p "${HOME}/.themes";
+  checkprogram 'git';
+  checkprogram 'wpg';
+  mkdir -p "${HOME}/.themes/color_other";
   mkdir -p "${HOME}/.icons";
   git clone https://github.com/deviantfero/wpgtk-themes "$THEME_DIR";
-  cd "$THEME_DIR";
+  if [[ $? -eq 0 ]]; then
+    cd "$THEME_DIR";
+    return 0;
+  else
+    exit 1;
+  fi
 }
 
 function install_tint2 ()
@@ -43,11 +54,32 @@ function install_tint2 ()
   read -r response;
   if [[ ! "$response" == "n" ]]; then
     echo "Installing tint2 config";
-    cp ./tint2/* "${HOME}/.config/tint2/" && \
-      echo ":: tint2 conf install done.";
+    echo ":: backing up current tint2 conf in tint2rc.old.bak";
+    cp "${HOME}/.config/tint2/tint2rc" "${HOME}/.config/tint2/tint2rc.old.bak" 2>/dev/null;
+    cp --remove-destination ./tint2/tint2rc "${HOME}/.config/tint2/tint2rc" && \
+    cp --remove-destination ./tint2/tint2rc.base "${COLOR_OTHER}" && \
+      ln -sf "${HOME}/.config/tint2/tint2rc" "${COLOR_OTHER}/tint2rc" && \
+      echo ":: tint2 template install done."
     return 0;
   fi
-  echo ":: tint2 conf not installed";
+  echo ":: tint2 template not installed";
+}
+
+function install_rofi ()
+{
+  echo -n "This might override your rofi config, Continue?[Y/n]: ";
+  read -r response;
+  if [[ ! "$response" == "n" ]]; then
+    echo "Installing rofi config";
+    echo ":: backing up current rofi conf in rofi.bak";
+    cp "${HOME}/.config/rofi/config" "${HOME}/.config/rofi/config.bak" 2>/dev/null;
+    cp --remove-destination ./rofi/config "${HOME}/.config/rofi/config" && \
+    cp --remove-destination ./rofi/rofi.base "${COLOR_OTHER}" && \
+      ln -sf "${HOME}/.config/rofi/config" "${COLOR_OTHER}/rofi" && \
+      echo ":: rofi template install done."
+    return 0;
+  fi
+  echo ":: rofi template not installed";
 }
 
 function install_gtk ()
@@ -67,16 +99,12 @@ function install_icons()
 function install_openbox()
 {
   echo "Installing openbox themes";
-  cp -r ./openbox/* "${HOME}/.themes/" && \
-    echo ":: colorbamboo openbox themes install done.";
-}
-
-function install_all()
-{
-  install_tint2;
-  install_gtk;
-  install_icons;
-  install_openbox;
+  cp --remove-destination -r ./openbox/colorbamboo/* "${HOME}/.themes/colorbamboo"
+  if [[ $? -eq 0 ]]; then
+    mv "${HOME}/.themes/colorbamboo/openbox-3/themerc.base" "${COLOR_OTHER}/ob_colorbamboo.base";
+    ln -sf "${HOME}/.themes/colorbamboo/openbox-3/themerc" "${COLOR_OTHER}/ob_colorbamboo" && \
+      echo ":: colorbamboo openbox themes install done.";
+  fi
 }
 
 function clean_up()
@@ -89,53 +117,45 @@ function clean_up()
 #  Handle command line arguments
 #-----------------------------------------------------------------------
 
-while getopts ":hvotgia" opt
-do
-  case $opt in
-    h|help)
-      usage;
-      exit 0
-      ;;
-    v|version)
-      echo "$0 -- Version $__ScriptVersion";
-      exit 0;
-      ;;
-    o|openbox)
-      getfiles;
-      install_openbox;
-      clean_up;
-      exit 0;
-      ;;
-    i|icons)
-      getfiles;
-      install_icons;
-      clean_up;
-      exit 0;
-      ;;
-    g|gtk)
-      getfiles;
-      install_gtk;
-      clean_up;
-      exit 0;
-      ;;
-    t|tint2)
-      getfiles;
-      install_tint2;
-      clean_up;
-      exit 0;
-      ;;
-    a|all)
-      getfiles;
-      install_all;
-      clean_up;
-      exit 0;
-      ;;
-    *)
-      echo -e "\n  Option does not exist : $OPTARG\n"
-      usage;
-      exit 1
-      ;;
+function getargs()
+{
+  while getopts ":hvotgir" opt
+  do
+    case $opt in
+      h)
+        usage;
+        exit 0
+        ;;
+      v)
+        echo "$0 -- Version $__ScriptVersion";
+        exit 0;
+        ;;
+      o) openbox="true" ;;
+      i)   icons="true" ;;
+      g)     gtk="true" ;;
+      t)   tint2="true" ;;
+      r)    rofi="true" ;;
+      *)
+        echo -e "\n  Option does not exist : $OPTARG\n"
+        usage;
+        exit 1
+        ;;
 
-    esac
-  done
-  shift "$((OPTIND - 1))"
+      esac
+    done
+    shift "$((OPTIND - 1))"
+}
+
+function main()
+{
+  getargs "$@";
+  getfiles;
+  [[ "$openbox" == "true" ]] && install_openbox;
+  [[ "$tint2" == "true" ]] && install_tint2;
+  [[ "$rofi" == "true" ]] && install_rofi;
+  [[ "$gtk" == "true" ]] && install_gtk;
+  [[ "$icons" == "true" ]] && install_icons;
+  clean_up;
+}
+
+main "$@"

--- a/wpgtk/misc/wpg-install.sh
+++ b/wpgtk/misc/wpg-install.sh
@@ -54,21 +54,21 @@ function install_gtk ()
 {
   echo "Installing gtk themes";
   cp -r ./FlatColor "${HOME}/.themes/" && \
-    echo ":: gtk themes install done."
+    echo ":: FlatColor gtk themes install done."
 }
 
 function install_icons()
 {
   echo "Installing icon pack";
   cp -r flattrcolor "${HOME}/.icons/" && \
-    echo ":: icons install done."
+    echo ":: flattr icons install done."
 }
 
 function install_openbox()
 {
   echo "Installing openbox themes";
   cp -r ./openbox/* "${HOME}/.themes/" && \
-    echo ":: openbox themes install done.";
+    echo ":: colorbamboo openbox themes install done.";
 }
 
 function install_all()


### PR DESCRIPTION
I need to clear confusion on how this system works, it is a simple way to add support for any software to have it's own template and it's own colors changed each time `wpgtk` changes the colorscheme, for this reason I feel it should be the main focus of the proyect, `GTK`, `tint2` and `openbox` are just special cases of these templates. In order to do so, I plan to clear up some things:

### Todo
- [x] Change **Optional Files** to **Templates** to better convey their porpouse.
- [x] Remove more unnecessary classes.
- [x] Improve wpg-install.sh 
- [x]  Be able to add templates from `cli` tool.
- [x]  treat ~GTK~, openbox, tint2 and rofi as templates too. (GTK has to many variants 2, 3.0, 3.20).
  - [x] add rofi to default templates  
  - [x] modify wpg-install.sh for this pourpose.
  - [x] setup a way to update old user's config files (added the possibility to reconnect base files).
- [x] Add an entry to the readme that is more clear on how to use this feature.
