### PR TITLE
change new keyword syntax to avoid conflicts in overlapping keyword

### DIFF
--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -24,8 +24,8 @@ def is_dark_theme(color_list):
 def get_random_color(image_name):
     image_path = join(config.WALL_DIR, image_name)
     if not config.RCC:
-        config.RCC = pywal.colors.gen_colors(image_path, 36)
-    return config.RCC[randint(0, len(config.RCC))]
+        config.RCC = pywal.colors.gen_colors(image_path, 48)
+    return config.RCC[randint(0, len(config.RCC) - 1)]
 
 
 def write_colors(img, color_list):

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -58,13 +58,12 @@ def change_colors(colors, which):
 
         if 'wpgtk-ignore' not in first_line:
             for k, v in config.keywords.items():
-                tmp_data = tmp_data.replace(k, v)
-            for k, v in colors['wpgtk'].items():
+                tmp_data = tmp_data.replace(util.build_key(k), v)
+            for k, v in colors["wpgtk"].items():
+                tmp_data = tmp_data.replace(util.build_key(k), v.strip('#'))
+            for k, v in colors["colors"].items():
+                k = util.build_key(k).upper()
                 tmp_data = tmp_data.replace(k, v.strip('#'))
-            for i in range(16):
-                k = 'COLOR%d' % i if i < 10 else 'COLORX%d' % i
-                v = colors['colors']['color%s' % i].strip('#')
-                tmp_data = tmp_data.replace(k, v)
 
             if colors['icons'] and opt == 'icon-step1':
                 for k, v in colors['icons'].items():

--- a/wpgtk/data/config.py
+++ b/wpgtk/data/config.py
@@ -3,7 +3,7 @@ import shutil
 import os
 import sys
 
-__version__ = '4.9.2'
+__version__ = '4.9.3'
 
 options = None
 wpgtk = None

--- a/wpgtk/data/util.py
+++ b/wpgtk/data/util.py
@@ -1,5 +1,5 @@
 from colorsys import rgb_to_hls, hls_to_rgb
-from pywal.util import rgb_to_hex, hex_to_rgb
+from pywal.util import hex_to_rgb
 
 
 def get_hls_val(hexv, what):
@@ -46,3 +46,7 @@ def add_brightness(hex_string, amount, sat=0):
     s = max(s - sat, -1)
 
     return hls_to_hex([h, l, s])
+
+
+def build_key(keyword):
+    return "<{}>".format(keyword)

--- a/wpgtk/data/util.py
+++ b/wpgtk/data/util.py
@@ -1,5 +1,5 @@
 from colorsys import rgb_to_hls, hls_to_rgb
-from pywal.util import hex_to_rgb
+from pywal.util import rgb_to_hex, hex_to_rgb
 
 
 def get_hls_val(hexv, what):

--- a/wpgtk/misc/wpg-install.sh
+++ b/wpgtk/misc/wpg-install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 __ScriptVersion="0.1.5";
-THEME_DIR="${PWD}/wpgtk-themes";
+THEME_DIR="${PWD}/wpgtk-templates";
 COLOR_OTHER="${HOME}/.config/wpg/templates";
 
 #===  FUNCTION  ================================================================
@@ -40,7 +40,7 @@ function getfiles ()
   checkprogram 'wpg';
   mkdir -p "${HOME}/.themes/color_other";
   mkdir -p "${HOME}/.icons";
-  git clone https://github.com/deviantfero/wpgtk-themes "$THEME_DIR";
+  git clone https://github.com/deviantfero/wpgtk-templates "$THEME_DIR";
   if [[ $? -eq 0 ]]; then
     cd "$THEME_DIR";
     return 0;

--- a/wpgtk/misc/wpg-install.sh
+++ b/wpgtk/misc/wpg-install.sh
@@ -22,6 +22,7 @@ function usage ()
   -r   Install rofi template
   -I   Install i3 template
   -p   Install polybar template
+  -H   Specify hash of wpgtk-templates repository to use
   "
 }
 
@@ -43,6 +44,7 @@ function getfiles ()
   git clone https://github.com/deviantfero/wpgtk-templates "$THEME_DIR";
   if [[ $? -eq 0 ]]; then
     cd "$THEME_DIR";
+    [[ ! -z "$commit" ]] && git checkout $commit;
     return 0;
   else
     exit 1;
@@ -163,7 +165,7 @@ function clean_up()
 
 function getargs()
 {
-  while getopts ":hvotgiIpr" opt
+  while getopts "H:hvotgiIpr" opt
   do
     case $opt in
       h)
@@ -181,6 +183,7 @@ function getargs()
       r)    rofi="true" ;;
       I)      i3="true" ;;
       p) polybar="true" ;;
+      H) commit="${OPTARG}" ;;
       *)
         echo -e "\n  Option does not exist : $OPTARG\n"
         usage;


### PR DESCRIPTION
Previously overlapping keywords would conflict, an example of this below:

```
KEYWORD1  -> firstvalue
KEYWORD11 -> firstvalue1
```

resulting in corrupted configuration files unless the keywords were completely different from one another, for this reason I've introduced this new syntax for keywords on template files, this is the same example above with the new syntax.

```
<KEYWORD1>  -> firstvalue
<KEYWORD11> -> differentvalue
```
This resolves the issue and allows for any keyword, wether it's overlaping or not, to be available to the user, this also means that `wpgtk` own color keywords can be simpler, and they're now defined as follows.

```
COLOR1   becomes <COLOR1>
COLORX10 becomes <COLOR10>
COLORACT becomes <COLORACT>
COLORIN  becomes <COLORIN>
```

So we have our 15 colors in `<COLOR1...15>`, no strange syntax involved.
