### PR TITLE
Import/export colorschemes

### DIFF
--- a/completions/bash/wpg
+++ b/completions/bash/wpg
@@ -1,7 +1,8 @@
 function _wpg() {
     local optforprofiles
     _get_comp_words_by_ref cur
-    optforprofiles="-s -e -d -z -T -m"
+    optforprofiles="-s -e -d -z -m"
+    optvariable="-i"
     optfordefault="-y -a -xa -ax"
     optfortemplates="-xd -dx"
 
@@ -11,6 +12,13 @@ function _wpg() {
         for opt in $optforprofiles; do
             if [[ $opt = ${COMP_WORDS[1]} ]]; then
                 COMPREPLY=($(compgen -W "$(wpg -l)" -- "$cur"))
+            fi
+        done
+        for opt in $optvariable; do
+            if [[ $opt = ${COMP_WORDS[1]} && $COMP_CWORD < 3 ]]; then
+                COMPREPLY=($(compgen -W "$(wpg -l)" -- "$cur"))
+            else
+                compopt -o default; COMPREPLY=()
             fi
         done
         for opt in $optfordefault; do

--- a/completions/bash/wpg
+++ b/completions/bash/wpg
@@ -2,7 +2,7 @@ function _wpg() {
     local optforprofiles
     _get_comp_words_by_ref cur
     optforprofiles="-s -e -d -z -m"
-    optvariable="-i"
+    optvariable="-i -o"
     optfordefault="-y -a -xa -ax"
     optfortemplates="-xd -dx"
 

--- a/completions/bash/wpg
+++ b/completions/bash/wpg
@@ -17,7 +17,7 @@ function _wpg() {
         for opt in $optvariable; do
             if [[ $opt = ${COMP_WORDS[1]} && $COMP_CWORD < 3 ]]; then
                 COMPREPLY=($(compgen -W "$(wpg -l)" -- "$cur"))
-            else
+            elif [[ $opt = ${COMP_WORDS[1]} ]]; then
                 compopt -o default; COMPREPLY=()
             fi
         done

--- a/completions/bash/wpg
+++ b/completions/bash/wpg
@@ -1,7 +1,7 @@
 function _wpg() {
     local optforprofiles
     _get_comp_words_by_ref cur
-    optforprofiles="-s -e -d -z"
+    optforprofiles="-s -e -d -z -T -m"
     optfordefault="-y -a -xa -ax"
     optfortemplates="-xd -dx"
 

--- a/completions/zsh/_wpg
+++ b/completions/zsh/_wpg
@@ -14,7 +14,7 @@ _templates() {
 
 _wpg() {
     local state optforprofiles
-    optforprofiles=(-s -e -d -z)    # options for which profiles should be completed
+    optforprofiles=(-s -e -d -z -T -m)    # options for which profiles should be completed
     optforgeneric=(-y -a -xa)
     optfortemplates=(-xd -dx)
 

--- a/completions/zsh/_wpg
+++ b/completions/zsh/_wpg
@@ -14,7 +14,8 @@ _templates() {
 
 _wpg() {
     local state optforprofiles
-    optforprofiles=(-s -e -d -z -T -m)    # options for which profiles should be completed
+    optforprofiles=(-s -e -d -z -m)    # options for which profiles should be completed
+    optvariable=(-i)
     optforgeneric=(-y -a -xa)
     optfortemplates=(-xd -dx)
 
@@ -33,6 +34,13 @@ _wpg() {
                         _profiles
                     fi
                 done
+                for opt in $optvariable; do
+                    if [[ $opt = ${words[2]} && $CURRENT < 4 ]]; then
+                        _profiles
+                    else
+                        _gnu_generic
+                    fi
+                done
                 for opt in $optforgeneric; do
                     if [[ $opt = ${words[2]} ]]; then
                         _gnu_generic
@@ -43,7 +51,7 @@ _wpg() {
                         _templates
                     fi
                 done
-            fi
+            fi 
             ;;
     esac
 }

--- a/completions/zsh/_wpg
+++ b/completions/zsh/_wpg
@@ -15,7 +15,7 @@ _templates() {
 _wpg() {
     local state optforprofiles
     optforprofiles=(-s -e -d -z -m)    # options for which profiles should be completed
-    optvariable=(-i)
+    optvariable=(-i -o)
     optforgeneric=(-y -a -xa)
     optfortemplates=(-xd -dx)
 

--- a/completions/zsh/_wpg
+++ b/completions/zsh/_wpg
@@ -37,7 +37,7 @@ _wpg() {
                 for opt in $optvariable; do
                     if [[ $opt = ${words[2]} && $CURRENT < 4 ]]; then
                         _profiles
-                    else
+                    elif [[ $opt = ${words[2]} ]]; then
                         _gnu_generic
                     fi
                 done

--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -68,6 +68,7 @@ def main():
                         help="add an existent basefile template [config, basefile]",
                         nargs='*')
 
+    config.init()
     args = parser.parse_args()
 
     if args.m == "random_both":
@@ -156,5 +157,4 @@ def main():
 
 
 if __name__ == "__main__":
-    config.init()
     main()

--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -147,12 +147,12 @@ def main():
         except NameError:
             logger.log.error("missing pygobject module, use cli")
 
-    if args.T:
-        if len(args.T) != 2:
+    if args.i:
+        if len(args.i) != 2:
             logger.log.error("specify a wallpaper and a colorscheme json")
             exit(1)
-        color.write_colors(args.T[0], color.get_color_list(args.T[1], True))
-        logger.log.info("applied %s to %s" % (args.T[1], args.T[0]))
+        color.write_colors(args.i[0], color.get_color_list(args.i[1], True))
+        logger.log.info("applied %s to %s" % (args.i[1], args.i[0]))
 
 
 if __name__ == "__main__":

--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -4,7 +4,7 @@ import random
 import wpgtk.data.config as config
 from os import path
 from subprocess import Popen
-from wpgtk.data import files, themer
+from wpgtk.data import files, themer, logger, color
 from wpgtk.data.config import __version__
 try:
     from wpgtk.gui import theme_picker
@@ -16,52 +16,68 @@ import argparse
 def main():
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('-s',
-                        help='set the wallpaper and colorscheme, apply \
-                        changes system-wide',
-                        nargs='*')
-    parser.add_argument('-r',
-                        help='restore the wallpaper and colorscheme',
-                        action='store_true')
-    parser.add_argument('-m',
-                        help='pick a random wallpaper and set it',
-                        action='store_true')
-    parser.add_argument('-a',
-                        help='add images to the wallpaper folder and generate \
-                        colorschemes',
-                        nargs='*')
+    parser.add_argument("-s",
+                        help="set the wallpaper and colorscheme, apply changes system-wide",
+                        nargs="*")
+
+    parser.add_argument("-r",
+                        help="restore the wallpaper and colorscheme",
+                        action="store_true")
+
+    parser.add_argument("-m",
+                        help="pick a random colorscheme and set it, specify wallpaper to avoid changing it",
+                        const="random_both", nargs="?")
+
+    parser.add_argument("-a",
+                        help="add a wallpaper and generate a colorscheme",
+                        nargs="*")
+
     parser.add_argument('-l',
-                        help='see which wallpapers are available',
-                        action='store_true')
-    parser.add_argument('--version',
-                        help='print the current version',
-                        action='store_true')
-    parser.add_argument('-d',
-                        help='delete the wallpaper(s) from wallpaper folder',
-                        nargs='*')
-    parser.add_argument('-c',
-                        help='shows the current wallpaper',
-                        action='store_true')
-    parser.add_argument('-z',
-                        help='shuffles the given colorscheme(s)',
-                        nargs='*')
-    parser.add_argument('-t',
-                        help='send color sequences to all terminals VTE true',
-                        action='store_true')
-    parser.add_argument('-x',
-                        help='add, remove and list \
-                             templates instead of themes',
-                        action='store_true')
-    parser.add_argument('-y',
-                        help='add an existent basefile template [config, basefile]',
+                        help="see which wallpapers are available",
+                        action="store_true")
+
+    parser.add_argument("--version",
+                        help="print the current version",
+                        action="store_true")
+
+    parser.add_argument("-d",
+                        help="delete the wallpaper(s) from wallpaper folder",
+                        nargs="*")
+
+    parser.add_argument("-c",
+                        help="shows the current wallpaper",
+                        action="store_true")
+
+    parser.add_argument("-z",
+                        help="shuffles the given colorscheme(s)",
+                        nargs="*")
+
+    parser.add_argument("-T",
+                        help="asign a theme in json format to wallpaper [wallpaper, json]",
+                        nargs="*")
+
+    parser.add_argument("-t",
+                        help="send color sequences to all terminals VTE true",
+                        action="store_true")
+
+    parser.add_argument("-x",
+                        help="add, remove and list templates instead of themes",
+                        action="store_true")
+
+    parser.add_argument("-y",
+                        help="add an existent basefile template [config, basefile]",
                         nargs='*')
 
-    config.init()
     args = parser.parse_args()
+
+    if args.m == "random_both":
+        filename = random.choice(files.get_file_list())
+        themer.set_theme(filename, filename)
+        exit(0)
 
     if args.m:
         filename = random.choice(files.get_file_list())
-        themer.set_theme(filename, filename)
+        themer.set_theme(args.m, filename)
         exit(0)
 
     if args.s:
@@ -69,30 +85,30 @@ def main():
             try:
                 themer.set_theme(args.s[0], args.s[0], args.r)
             except TypeError as e:
-                print('ERR:: file ' + args.s[0] + ' not found')
+                logger.log.error("file " + args.s[0] + " not found")
                 raise e
         elif len(args.s) == 2:
             try:
                 themer.set_theme(args.s[0], args.s[1], args.r)
             except TypeError:
-                print('ERR:: file  not found')
+                logger.log.error("file  not found")
         elif len(args.s) > 2:
-            print('ERR:: Specify just 2 filenames')
+            logger.log.error("specify just 2 filenames")
 
     if args.l:
         if args.x:
             templates = files.get_file_list(config.OPT_DIR, False)
-            [print(t) for t in templates if '.base' in t]
+            [print(t) for t in templates if ".base" in t]
         else:
             files.show_files()
         exit(0)
 
     if args.t:
-        Popen(['cat', path.join(config.WPG_DIR, 'sequences')])
+        Popen(["cat", path.join(config.WPG_DIR, "sequences")])
         exit(0)
 
     if args.version:
-        print('current version: ' + __version__)
+        print("current version: " + __version__)
         exit(0)
 
     if args.d:
@@ -118,7 +134,7 @@ def main():
         for arg in args.z:
             themer.shuffle_colors(arg)
             themer.auto_adjust_theme(arg)
-            print('OK:: shuffled %s' % arg)
+            logger.log.info("shuffled %s" % arg)
         exit(0)
 
     if args.y:
@@ -129,8 +145,16 @@ def main():
         try:
             theme_picker.run(args)
         except NameError:
-            print('ERR:: missing pygobject module, use cli', file=sys.stderr)
+            logger.log.error("missing pygobject module, use cli")
+
+    if args.T:
+        if len(args.T) != 2:
+            logger.log.error("specify a wallpaper and a colorscheme json")
+            exit(1)
+        color.write_colors(args.T[0], color.get_color_list(args.T[1], True))
+        logger.log.info("applied %s to %s" % (args.T[1], args.T[0]))
 
 
 if __name__ == "__main__":
+    config.init()
     main()

--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -52,8 +52,8 @@ def main():
                         help="shuffles the given colorscheme(s)",
                         nargs="*")
 
-    parser.add_argument("-T",
-                        help="asign a theme in json format to wallpaper [wallpaper, json]",
+    parser.add_argument("-i",
+                        help="import a theme in json format and asign to wallpaper [wallpaper, json]",
                         nargs="*")
 
     parser.add_argument("-t",

--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -56,6 +56,10 @@ def main():
                         help="import a theme in json format and asign to wallpaper [wallpaper, json]",
                         nargs="*")
 
+    parser.add_argument("-o",
+                        help="export a theme in json format [wallpaper, json path]",
+                        nargs="*")
+
     parser.add_argument("-t",
                         help="send color sequences to all terminals VTE true",
                         action="store_true")
@@ -133,7 +137,7 @@ def main():
 
     if args.z:
         for arg in args.z:
-            themer.shuffle_colors(arg)
+            color.shuffle_colors(arg)
             themer.auto_adjust_theme(arg)
             logger.log.info("shuffled %s" % arg)
         exit(0)
@@ -152,8 +156,16 @@ def main():
         if len(args.i) != 2:
             logger.log.error("specify a wallpaper and a colorscheme json")
             exit(1)
-        color.write_colors(args.i[0], color.get_color_list(args.i[1], True))
-        logger.log.info("applied %s to %s" % (args.i[1], args.i[0]))
+        themer.import_theme(args.i[0], args.i[1])
+
+    if args.o:
+        if len(args.o) == 2:
+            themer.export_theme(args.o[0], args.o[1])
+        elif len(args.o) == 1:
+            themer.export_theme(args.o[0])
+        else:
+            logger.log.error("specify wallpaper and optionally an output path")
+            exit(1)
 
 
 if __name__ == "__main__":

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -1,9 +1,10 @@
 import shutil
 import sys
 from subprocess import call
+from random import shuffle
 from os.path import join, isfile
 from random import randint
-from . import config, files, util, logger
+from . import config, files, util, logger, sample
 import pywal
 
 
@@ -30,6 +31,19 @@ def get_random_color(image_name):
     if not config.RCC:
         config.RCC = pywal.colors.gen_colors(image_path, 48)
     return config.RCC[randint(0, len(config.RCC) - 1)]
+
+
+def shuffle_colors(filename):
+    try:
+        colors = get_color_list(filename)
+        shuffled_colors = colors[1:7]
+        shuffle(shuffled_colors)
+        colors = colors[:1] + shuffled_colors + colors[7:]
+        sample.create_sample(colors, join(config.SAMPLE_DIR,
+                             filename + '.sample.png'))
+        write_colors(filename, colors)
+    except IOError as e:
+        logger.log.error('file not available')
 
 
 def write_colors(img, color_list):

--- a/wpgtk/data/config.py
+++ b/wpgtk/data/config.py
@@ -1,7 +1,7 @@
 import configparser
 import shutil
 import os
-import sys
+from . import logger
 
 __version__ = '4.9.4'
 
@@ -49,7 +49,7 @@ def load_sections():
 def init():
     try:
         if not os.path.isdir(SCHEME_DIR):
-            print('INF:: Creating dirs...')
+            logger.log.info('creating dirs...')
             os.makedirs(XRES_DIR, exist_ok=True)
             os.makedirs(SAMPLE_DIR, exist_ok=True)
             os.makedirs(SCHEME_DIR, exist_ok=True)
@@ -57,8 +57,8 @@ def init():
         load_sections()
         return 0
     except:
-        print('ERR:: Not a valid config file', file=sys.stderr)
-        print('INF:: Copying default config file')
+        logger.log.error("not a valid config file")
+        logger.log.info("copying default config file")
         pass
 
     shutil.copy(CONF_BACKUP, CONF_FILE)

--- a/wpgtk/data/files.py
+++ b/wpgtk/data/files.py
@@ -1,13 +1,12 @@
 import os
 import shutil
-import sys
 import re
-from . import config
+from . import config, logger
 from pywal.settings import __cache_version__
 from os.path import join
 
 
-def get_file_list(path=config.WALL_DIR, images=True):
+def get_file_list(path=config.WALL_DIR, images=True, json=False):
     """gets filenames in a given directory, optional
     parameters for image exclusiveness
 
@@ -60,20 +59,20 @@ def add_template(cfile, basefile=None):
         templatename = '.'.join(l) + '.base'
     else:
         templatename = basefile.split('/').pop()
-    print('ADD::' + templatename + '@' + cfile)
+    logger.log.info('added ' + templatename + '@' + cfile)
     try:
-        print('::MAKING BACKUP CONFIG')
+        logger.log.info('MAKING BACKUP CONFIG')
         shutil.copy2(cfile, cfile + '.bak')
-        print('::CREATING BASE')
+        logger.log.info('CREATING BASE')
         if basefile:
             shutil.copy2(basefile, join(config.OPT_DIR, templatename))
         else:
             shutil.copy2(cfile, join(config.OPT_DIR, templatename))
-        print('::CREATING SYMLINK')
+        logger.log.info('CREATING SYMLINK')
         os.symlink(cfile, join(config.OPT_DIR,
                    templatename.replace('.base', '')))
     except Exception as e:
-        print('ERR::' + str(e.strerror), file=sys.stderr)
+        logger.log.error(str(e.strerror))
 
 
 def remove_template(basefile):
@@ -85,4 +84,4 @@ def remove_template(basefile):
         if os.path.islink(configfile_path):
             os.remove(configfile_path)
     except Exception as e:
-        print('ERR::' + str(e.strerror), file=sys.stderr)
+        logger.log.error(str(e.strerror))

--- a/wpgtk/data/logger.py
+++ b/wpgtk/data/logger.py
@@ -1,0 +1,11 @@
+import logging
+
+log = logging.getLogger("wpgtk")
+log.setLevel(logging.DEBUG)
+
+ch = logging.StreamHandler()
+ch.setLevel(logging.DEBUG)
+
+formatter = logging.Formatter("[%(name)s][%(levelname)s] %(message)s")
+ch.setFormatter(formatter)
+log.addHandler(ch)

--- a/wpgtk/data/sample.py
+++ b/wpgtk/data/sample.py
@@ -5,7 +5,7 @@ try:
     import Image
 except ImportError:
     from PIL import Image
-    
+
 import pywal
 
 

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -5,7 +5,7 @@ from random import shuffle
 from os.path import realpath
 from os import symlink, remove, path
 from subprocess import Popen, call
-from . import color, sample, config, files
+from . import color, sample, config, files, logger
 
 
 def create_theme(filepath):
@@ -83,7 +83,7 @@ def shuffle_colors(filename):
                              filename + '.sample.png'))
         color.write_colors(filename, colors)
     except IOError as e:
-        print('ERR:: file not available')
+        logger.log.error('file not available')
 
 
 def auto_adjust_theme(filename):
@@ -95,4 +95,4 @@ def auto_adjust_theme(filename):
                                          (filename + '.sample.png')))
         color.write_colors(filename, color_list)
     except IOError:
-        print('ERR:: file not available')
+        logger.log.error('file not available')

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -1,7 +1,6 @@
 import errno
 import pywal
 import shutil
-from random import shuffle
 from os.path import realpath
 from os import symlink, remove, path
 from subprocess import Popen, call
@@ -73,15 +72,22 @@ def get_current(show=False):
     return image
 
 
-def shuffle_colors(filename):
+def import_theme(wallpaper, json_file):
+    color_list = color.get_color_list(json_file, True)
+
+    color.write_colors(wallpaper, color_list)
+    sample.create_sample(color_list,
+                         path.join(config.SAMPLE_DIR,
+                                   (wallpaper + '.sample.png')))
+    logger.log.info("applied %s to %s" % (json_file, wallpaper))
+
+
+def export_theme(wallpaper, json_path="."):
     try:
-        colors = color.get_color_list(filename)
-        shuffled_colors = colors[1:7]
-        shuffle(shuffled_colors)
-        colors = colors[:1] + shuffled_colors + colors[7:]
-        sample.create_sample(colors, f=path.join(config.SAMPLE_DIR,
-                             filename + '.sample.png'))
-        color.write_colors(filename, colors)
+        if(path.isdir(json_path)):
+            json_path = path.join(json_path, wallpaper + ".json")
+        shutil.copy2(path.join(files.get_cache_filename(wallpaper)), json_path)
+        logger.log.info("theme for %s successfully exported", wallpaper)
     except IOError as e:
         logger.log.error('file not available')
 

--- a/wpgtk/gui/template_grid.py
+++ b/wpgtk/gui/template_grid.py
@@ -1,10 +1,9 @@
-import sys
 from gi.repository import Gtk
 from gi.repository.GdkPixbuf import Pixbuf
 import os
 from gi import require_version
 from subprocess import Popen
-from wpgtk.data import config, files
+from wpgtk.data import config, files, logger
 require_version("Gtk", "3.0")
 
 PAD = 10
@@ -102,7 +101,7 @@ class TemplateGrid(Gtk.Grid):
             try:
                 Popen(args_list)
             except Exception as e:
-                print("ERR:: malformed editor command", sys.stderr)
+                logger.log.error("malformed editor command")
             self.current = None
         self.file_view.unselect_all()
 

--- a/wpgtk/gui/theme_picker.py
+++ b/wpgtk/gui/theme_picker.py
@@ -1,7 +1,7 @@
 from gi import require_version
 from . import color_grid, template_grid
 from . import option_grid, keyword_grid
-from wpgtk.data import files, themer, config
+from wpgtk.data import files, themer, config, logger
 from gi.repository import Gtk, GdkPixbuf
 import os
 require_version('Gtk', '3.0')
@@ -22,7 +22,7 @@ class mainWindow(Gtk.Window):
         # these variables are just to get the image
         # and preview of current wallpaper
         file_name = themer.get_current()
-        print('INF::CURRENT WALL: ' + file_name)
+        logger.log.info('current wallpaper: ' + file_name)
         sample_name = os.path.join(config.SAMPLE_DIR,
                                    (file_name + '.sample.png'))
 
@@ -63,8 +63,6 @@ class mainWindow(Gtk.Window):
         self.colorscheme.set_entry_text_column(0)
 
         self.set_border_width(10)
-        # another container will be added so this will probably change
-        # self.add(self.wpage)
         self.preview = Gtk.Image()
         self.sample = Gtk.Image()
 
@@ -100,7 +98,6 @@ class mainWindow(Gtk.Window):
         self.current_walls = Gtk.ComboBox()
 
     def on_add_clicked(self, widget):
-        filepath = ""
         filechooser = Gtk.FileChooserDialog(
                       'Select an Image', self,
                       Gtk.FileChooserAction.OPEN,
@@ -116,19 +113,16 @@ class mainWindow(Gtk.Window):
         response = filechooser.run()
 
         if response == Gtk.ResponseType.OK:
-            filepath = filechooser.get_filename()
+            themer.create_theme(filechooser.get_filename())
+            option_list = Gtk.ListStore(str)
+            for elem in list(files.get_file_list()):
+                option_list.append([elem])
+            self.option_combo.set_model(option_list)
+            self.option_combo.set_entry_text_column(0)
+            self.colorscheme.set_model(option_list)
+            self.colorscheme.set_entry_text_column(0)
+            self.cpage.update_combo(option_list)
         filechooser.destroy()
-
-        themer.create_theme(filepath)
-        option_list = Gtk.ListStore(str)
-
-        for elem in list(files.get_file_list()):
-            option_list.append([elem])
-        self.option_combo.set_model(option_list)
-        self.option_combo.set_entry_text_column(0)
-        self.colorscheme.set_model(option_list)
-        self.colorscheme.set_entry_text_column(0)
-        self.cpage.update_combo(option_list)
 
     def on_set_clicked(self, widget):
         x = self.option_combo.get_active()


### PR DESCRIPTION
In a similar fashion to what dylan is doing in https://github.com/dylanaraps/pywal/pull/200, I've implemented a way to import either https://terminal.sexy format JSON colorschemes, or pywal's own colorschemes can be imported this way too. This is achieved with a new flag `-i`, it works like this

```
wpg -i wallpaper.jpg /path/to/colorscheme.json
```

this way you can backup your favourite colorschemes and load them up whenever you want and assign them to any wallpaper you wish to, and of course you can use the UI to make use of this new feature too.

![example](https://i.imgur.com/m8meH7H.png)