### PR TITLE
pywal themes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ In short, `wpgtk` is a colorscheme/wallpaper manager with a template system atta
 [[Command Line](https://www.youtube.com/watch?v=yjNipQZpOUc)]
 [[Import/export Colorschemes](https://www.youtube.com/watch?v=P3D0jtG6G2s)]
 
+- **Other Repos:**
+[[wpgtk.vim](https://github.com/deviantfero/wpgtk.vim)]
+[[wpgtk-templates](https://github.com/deviantfero/wpgtk-templates)]
+[[wpgtk-colorschemes](https://github.com/deviantfero/wpgtk-colorschemes)]
+
 
 
 ## Gallery

--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@
 `wpgtk` uses [pywal](https://github.com/dylanaraps/pywal) as it's colorscheme generator, but builds upon it with a UI and other features, such as the abilty to mix and edit the colorschemes generated and save them with their respective wallpapers, having light and dark themes, hackable and fast GTK+ theme made specifically for `wpgtk` and custom keywords and values to replace in templates.
 
 For those who are not into automatic generated colorschemes, you can now also import colorschemes
-in JSON format, you can upload and download themes from the [wpgtk-colorschemes](https://github.com/deviantfero/wpgtk-colorschemes) repository.
+in JSON format, you can upload and download themes from the [wpgtk-colorschemes](https://github.com/deviantfero/wpgtk-colorschemes) repository, wpgtk is also compatible with all of `pywal`'s included themes, 
+that's more than 250 themes from the get go.
 
 In short, `wpgtk` is a colorscheme/wallpaper manager with a template system attached which let's you create templates from any textfile and will replace keywords on it on the fly, allowing for great styling and theming possibilities.
+
+## Usage
 
 - **Demos:**
 [[GUI](https://gfycat.com/RigidAnxiousElk)]
@@ -37,11 +40,10 @@ In short, `wpgtk` is a colorscheme/wallpaper manager with a template system atta
   <img src="https://i.imgur.com/UvVonun.gif"/>
 </p>
 
-![i3_setup](https://i.imgur.com/ybqWBO6.png)
-
-![light_theme](https://i.imgur.com/Pc2zRej.png)
-
-![openbox setup](http://i.imgur.com/2cquXzm.png)
+<div style="display: flex; width: 100%">
+  <img style="width: 50%;" src="https://i.imgur.com/jt9LlFE.png"/>
+  <img style="width: 50%;" src="https://i.imgur.com/GQ8vESj.png"/>
+</div>
 
 # License
 

--- a/completions/bash/wpg
+++ b/completions/bash/wpg
@@ -2,7 +2,7 @@ function _wpg() {
     local optforprofiles
     _get_comp_words_by_ref cur
     # themes
-    optforprofiles="-s -e -d -z -m -A --brt --sat"
+    optforprofiles="-s -e -d -z -m -LA -A --brt --sat"
     # themes, pywal themes
 	optforvariabletheme="-Ti"
     # themes, filenames

--- a/completions/bash/wpg
+++ b/completions/bash/wpg
@@ -1,12 +1,19 @@
 function _wpg() {
     local optforprofiles
     _get_comp_words_by_ref cur
-    optforprofiles="-s -e -d -z -m -A"
+    # themes
+    optforprofiles="-s -e -d -z -m -A --brt --sat"
+    # themes, pywal themes
 	optforvariabletheme="-Ti"
+    # themes, filenames
     optvariable="-i -o"
+	# filenames
     optfordefault="-y -a -xa -ax"
+	# templates
     optfortemplates="-xd -dx"
+	# pywal backends
 	optforbackends="--backends"
+	# pywal themes
 	optforthemes="--pywal"
 
     if [[ $COMP_CWORD = 1 ]]; then

--- a/completions/bash/wpg
+++ b/completions/bash/wpg
@@ -1,11 +1,13 @@
 function _wpg() {
     local optforprofiles
     _get_comp_words_by_ref cur
-    optforprofiles="-s -e -d -z -m"
+    optforprofiles="-s -e -d -z -m -A"
+	optforvariabletheme="-Ti"
     optvariable="-i -o"
     optfordefault="-y -a -xa -ax"
     optfortemplates="-xd -dx"
 	optforbackends="--backends"
+	optforthemes="--pywal"
 
     if [[ $COMP_CWORD = 1 ]]; then
         COMPREPLY=($(compgen -W "$(_parse_usage wpg)" -- "$cur"))
@@ -20,11 +22,23 @@ function _wpg() {
                 COMPREPLY=($(compgen -W "$(wpg --backends)" -- "$cur"))
             fi
         done
+        for opt in $optforthemes; do
+            if [[ $opt = ${COMP_WORDS[1]} ]]; then
+                COMPREPLY=($(compgen -W "$(wpg --pywal)" -- "$cur"))
+            fi
+        done
         for opt in $optvariable; do
             if [[ $opt = ${COMP_WORDS[1]} && $COMP_CWORD < 3 ]]; then
                 COMPREPLY=($(compgen -W "$(wpg -l)" -- "$cur"))
             elif [[ $opt = ${COMP_WORDS[1]} ]]; then
                 compopt -o default; COMPREPLY=()
+            fi
+        done
+        for opt in $optforvariabletheme; do
+            if [[ $opt = ${COMP_WORDS[1]} && $COMP_CWORD < 3 ]]; then
+                COMPREPLY=($(compgen -W "$(wpg -l)" -- "$cur"))
+            elif [[ $opt = ${COMP_WORDS[1]} ]]; then
+                COMPREPLY=($(compgen -W "$(wpg --pywal)" -- "$cur"))
             fi
         done
         for opt in $optfordefault; do

--- a/completions/zsh/_wpg
+++ b/completions/zsh/_wpg
@@ -1,9 +1,9 @@
 #compdef wpg
 
 _profiles() {
-    local -a profiles               #
-    profiles=(`wpg -l`)             # use output of wpg -l for completion
-    _describe 'profiles' profiles   #
+    local -a profiles
+    profiles=(`wpg -l`)
+    _describe 'profiles' profiles
 }
 
 _templates() {
@@ -26,12 +26,19 @@ _themes() {
 
 _wpg() {
     local state optforprofiles
-    optforprofiles=(-s -e -d -z -m -A)    # options for which profiles should be completed
+    # themes
+    optforprofiles=(-s -e -d -z -m -A --brt --sat) 
+    # themes, filenames
     optvariable=(-i -o)
+    # themes, pywal themes
     optvariabletheme=(-Ti)
+    # filenames
     optforgeneric=(-y -a -xa)
+    # templates
     optfortemplates=(-xd -dx)
+    # pywal backends
     optforbackends=(--backend)
+    # pywal themes
     optforthemes=(--pywal)
 
     _arguments \

--- a/completions/zsh/_wpg
+++ b/completions/zsh/_wpg
@@ -27,7 +27,7 @@ _themes() {
 _wpg() {
     local state optforprofiles
     # themes
-    optforprofiles=(-s -e -d -z -m -A --brt --sat) 
+    optforprofiles=(-s -e -d -z -m -A -LA --brt --sat) 
     # themes, filenames
     optvariable=(-i -o)
     # themes, pywal themes

--- a/completions/zsh/_wpg
+++ b/completions/zsh/_wpg
@@ -18,13 +18,21 @@ _backends() {
     _describe 'backends' backends
 }
 
+_themes() {
+    local -a themes
+    themes=(`wpg --pywal`)
+    _describe 'themes' themes
+}
+
 _wpg() {
     local state optforprofiles
-    optforprofiles=(-s -e -d -z -m)    # options for which profiles should be completed
+    optforprofiles=(-s -e -d -z -m -A)    # options for which profiles should be completed
     optvariable=(-i -o)
+    optvariabletheme=(-Ti)
     optforgeneric=(-y -a -xa)
     optfortemplates=(-xd -dx)
     optforbackends=(--backend)
+    optforthemes=(--pywal)
 
     _arguments \
         '1: :->generic' \
@@ -48,6 +56,13 @@ _wpg() {
                         _gnu_generic
                     fi
                 done
+                for opt in $optvariabletheme; do
+                    if [[ $opt = ${words[2]} && $CURRENT < 4 ]]; then
+                        _profiles
+                    elif [[ $opt = ${words[2]} ]]; then
+                        _themes
+                    fi
+                done
                 for opt in $optforgeneric; do
                     if [[ $opt = ${words[2]} ]]; then
                         _gnu_generic
@@ -61,6 +76,11 @@ _wpg() {
                 for opt in $optforbackends; do
                     if [[ $opt = ${words[2]} ]]; then
                         _backends
+                    fi
+                done
+                for opt in $optforthemes; do
+                    if [[ $opt = ${words[2]} ]]; then
+                        _themes
                     fi
                 done
             fi 

--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -52,7 +52,7 @@ def read_args(args):
                         help="shows the current wallpaper",
                         action="store_true")
 
-    parser.add_argument("--light",
+    parser.add_argument("-L", "--light",
                         help="temporarily enable light themes",
                         action="store_true")
 

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -1,4 +1,3 @@
-import shutil
 import sys
 import logging
 import pywal
@@ -186,16 +185,15 @@ def prepare_colors(cdic):
 def apply_colorscheme(colors):
     colors = prepare_colors(colors)
 
-    if config.wpgtk.getboolean('gtk'):
-        pywal.reload.gtk()
-
     if isfile(config.FILE_DIC['icon-step2']):
         change_colors(colors, 'icon-step1')
         call(config.FILE_DIC['icon-step2'])
 
     change_templates(colors)
 
-    if config.wpgtk.getboolean('tint2') or not shutil.which('tint2'):
-        call(["pkill", "-SIGUSR1", "tint2"])
-    if config.wpgtk.getboolean('openbox') and shutil.which('openbox'):
-        call(["openbox", "--reconfigure"])
+    if config.wpgtk.getboolean('tint2'):
+        util.reload_tint2()
+    if config.wpgtk.getboolean('openbox'):
+        util.reload_openbox()
+    if config.wpgtk.getboolean('gtk'):
+        pywal.reload.gtk()

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -172,7 +172,8 @@ def prepare_colors(cdic):
 
     # getting base colors
     if(config.wpgtk.getint('active') > 0):
-        bc = cl[config.wpgtk.getint('active') - 1]
+        print(config.wpgtk.getint('active'))
+        bc = cl[config.wpgtk.getint('active')]
     else:
         bc = cl[randint(0, 15)]
 

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -1,12 +1,15 @@
 import shutil
 import sys
 import logging
+import pywal
 from subprocess import call
 from random import shuffle
 from os.path import join, isfile
 from random import randint
-from . import config, files, util, sample
-import pywal
+from . import config
+from . import files
+from . import util
+from . import sample
 
 
 def get_pywal_dict(filename):
@@ -49,11 +52,7 @@ def shuffle_colors(colors):
 def write_colors(img, color_list):
     color_dict = get_pywal_dict(img)
 
-    for i in range(16):
-        color_dict['colors']['color%s' % i] = color_list[i]
-    color_dict['special']['background'] = color_list[0]
-    color_dict['special']['foreground'] = color_list[15]
-
+    color_dict = pywal.colors.colors_to_dict(color_list, img)
     cache_file = files.get_cache_path(img)
 
     pywal.export.color(color_dict, "json", cache_file)

--- a/wpgtk/data/config.py
+++ b/wpgtk/data/config.py
@@ -3,7 +3,7 @@ import shutil
 import os
 import logging
 
-__version__ = '5.0.4'
+__version__ = '5.5.0'
 
 options = None
 wpgtk = None

--- a/wpgtk/data/sample.py
+++ b/wpgtk/data/sample.py
@@ -10,7 +10,6 @@ import pywal
 
 
 def create_sample(colors, f=os.path.join(config.WALL_DIR, ".tmp.sample.png")):
-    print(colors, len(colors))
     im = Image.new("RGB", (480, 50), "white")
     pix = im.load()
 

--- a/wpgtk/data/sample.py
+++ b/wpgtk/data/sample.py
@@ -10,6 +10,7 @@ import pywal
 
 
 def create_sample(colors, f=os.path.join(config.WALL_DIR, ".tmp.sample.png")):
+    print(colors, len(colors))
     im = Image.new("RGB", (480, 50), "white")
     pix = im.load()
 
@@ -20,7 +21,7 @@ def create_sample(colors, f=os.path.join(config.WALL_DIR, ".tmp.sample.png")):
             for k in range(0, 25):
                 pix[j, k] = pywal.util.hex_to_rgb(c)
 
-    for i, c in enumerate(colors[8:]):
+    for i, c in enumerate(colors[8:16]):
         for j in range(width_sample*i, width_sample*i+width_sample):
             for k in range(25, 50):
                 pix[j, k] = pywal.util.hex_to_rgb(c)

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -22,8 +22,10 @@ def create_theme(filepath):
     return color.get_color_list(filename)
 
 
-def set_theme(filename, cs_file, restore=False, set_wall=True):
+def set_theme(filename, cs_file, restore=False):
+    set_wall = config.wgptk.getboolean("set_wallpaper", True)
     colors = color.get_pywal_dict(path.join(config.WALL_DIR, cs_file))
+
     if not restore:
         color.apply_colorscheme(colors)
         pywal.reload.gtk()
@@ -88,13 +90,13 @@ def import_theme(wallpaper, json_file, theme=False):
     logging.info("applied %s to %s" % (filename, wallpaper))
 
 
-def set_pywal_theme(theme_name, set_wall=True):
+def set_pywal_theme(theme_name):
     current = get_current()
     theme = pywal.theme.file(theme_name)
     color_list = list(theme["colors"].values())
     color.write_colors(current, color_list)
     sample.create_sample(color_list, files.get_sample_path(current))
-    set_theme(current, current, set_wall=set_wall)
+    set_theme(current, current)
 
 
 def export_theme(wallpaper, json_path="."):

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -23,19 +23,18 @@ def create_theme(filepath):
 
 
 def set_theme(filename, cs_file, restore=False):
-    set_wall = config.wgptk.getboolean("set_wallpaper", True)
+    set_wall = config.wpgtk.getboolean("set_wallpaper", True)
     colors = color.get_pywal_dict(path.join(config.WALL_DIR, cs_file))
+    pywal.sequences.send(colors, config.WPG_DIR)
 
     if not restore:
         color.apply_colorscheme(colors)
-        pywal.reload.gtk()
         pywal.reload.i3()
         pywal.reload.polybar()
 
     if set_wall:
         pywal.wallpaper.change(path.join(config.WALL_DIR, filename))
 
-    pywal.sequences.send(colors, config.WPG_DIR)
     pywal.export.color(colors, "css",
                        path.join(config.WPG_DIR, "current.css"))
     pywal.export.color(colors, "shell",

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -4,7 +4,11 @@ import logging
 from os.path import realpath
 from os import remove, path, symlink
 from subprocess import Popen
-from . import color, sample, config, files, util
+from . import color
+from . import config
+from . import files
+from . import util
+from . import sample
 
 
 def create_theme(filepath):
@@ -19,63 +23,78 @@ def create_theme(filepath):
 
 
 def set_theme(filename, cs_file, restore=False, set_wall=True):
-    if(path.join(config.WALL_DIR, filename)):
-        if not restore:
-            color.apply_colorscheme(cs_file)
-            pywal.reload.gtk()
-            pywal.reload.i3()
-            pywal.reload.polybar()
+    colors = color.get_pywal_dict(path.join(config.WALL_DIR, cs_file))
+    if not restore:
+        color.apply_colorscheme(colors)
+        pywal.reload.gtk()
+        pywal.reload.i3()
+        pywal.reload.polybar()
 
-        if set_wall:
-            pywal.wallpaper.change(path.join(config.WALL_DIR, filename))
-        colors = color.get_pywal_dict(path.join(config.WALL_DIR, cs_file))
+    if set_wall:
+        pywal.wallpaper.change(path.join(config.WALL_DIR, filename))
 
-        pywal.sequences.send(colors, config.WPG_DIR)
+    pywal.sequences.send(colors, config.WPG_DIR)
+    pywal.export.color(colors, "css",
+                       path.join(config.WPG_DIR, "current.css"))
+    pywal.export.color(colors, "shell",
+                       path.join(config.WPG_DIR, "current.sh"))
+    pywal.export.color(colors, "xresources",
+                       path.join(config.WPG_DIR, "current.Xres"))
 
-        pywal.export.color(colors, "css",
-                           path.join(config.WPG_DIR, "current.css"))
-        pywal.export.color(colors, "shell",
-                           path.join(config.WPG_DIR, "current.sh"))
-        pywal.export.color(colors, "xresources",
-                           path.join(config.WPG_DIR, "current.Xres"))
+    flags = "-rs" if set_wall else "-nrs"
+    with open(path.join(config.WPG_DIR, "wp_init.sh"), "w") as script:
+        script.writelines(["#!/bin/bash\n",
+                           "wpg %s %s %s" % (flags, filename, cs_file)])
 
-        with open(path.join(config.WPG_DIR, "wp_init.sh"), "w") as script:
-            script.writelines(["#!/bin/bash\n",
-                               "wpg -rs %s %s" % (filename, cs_file)])
+    Popen(['chmod', '+x', path.join(config.WPG_DIR, "wp_init.sh")])
+    util.xrdb_merge(path.join(config.XRES_DIR, cs_file + ".Xres"))
+    util.xrdb_merge(path.join(config.HOME, ".Xresources"))
 
-        Popen(['chmod', '+x', path.join(config.WPG_DIR, "wp_init.sh")])
-        util.xrdb_merge(path.join(config.XRES_DIR, cs_file + ".Xres"))
-        util.xrdb_merge(path.join(config.HOME, ".Xresources"))
+    files.change_current(filename)
 
-        files.change_current(filename)
-
-        if config.wpgtk.getboolean('execute_cmd'):
-            Popen(config.wpgtk['command'].split(' '))
-    else:
-        print("no such file, available files:")
-        files.show_files()
+    if config.wpgtk.getboolean('execute_cmd'):
+        Popen(config.wpgtk['command'].split(' '))
 
 
 def delete_theme(filename):
-    remove(path.join(config.WALL_DIR, filename))
-    remove(path.join(config.XRES_DIR, (filename + '.Xres')))
-    files.delete_colorschemes(filename)
+    try:
+        remove(path.join(config.WALL_DIR, filename))
+        remove(path.join(config.XRES_DIR, (filename + '.Xres')))
+        files.delete_colorschemes(filename)
+    except IOError as e:
+        logging.error("file not available")
 
 
-def get_current(show=False):
+def get_current():
     image = realpath(path.join(config.WPG_DIR, '.current')).split('/').pop()
-    if show:
-        print(image)
     return image
 
 
-def import_theme(wallpaper, json_file):
+def import_theme(wallpaper, json_file, theme=False):
     json_file = realpath(json_file)
-    color_list = color.get_color_list(json_file, True)
+    filename = json_file.split("/").pop()
+    if theme:
+        theme = pywal.theme.file(filename)
+        color_list = list(theme["colors"].values())
+    else:
+        try:
+            color_list = color.get_color_list(json_file, True)
+        except IOError:
+            logging.error("file does not exist")
+            return
 
     color.write_colors(wallpaper, color_list)
     sample.create_sample(color_list, files.get_sample_path(wallpaper))
-    logging.info("applied %s to %s" % (json_file, wallpaper))
+    logging.info("applied %s to %s" % (filename, wallpaper))
+
+
+def set_pywal_theme(theme_name, set_wall=True):
+    current = get_current()
+    theme = pywal.theme.file(theme_name)
+    color_list = list(theme["colors"].values())
+    color.write_colors(current, color_list)
+    sample.create_sample(color_list, files.get_sample_path(current))
+    set_theme(current, current, set_wall=set_wall)
 
 
 def export_theme(wallpaper, json_path="."):
@@ -85,4 +104,4 @@ def export_theme(wallpaper, json_path="."):
         shutil.copy2(path.join(files.get_cache_path(wallpaper)), json_path)
         logging.info("theme for %s successfully exported", wallpaper)
     except IOError as e:
-        logging.error('file not available')
+        logging.error("file not available")

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -93,9 +93,11 @@ def import_theme(wallpaper, json_file, theme=False):
 def set_pywal_theme(theme_name):
     current = get_current()
     theme = pywal.theme.file(theme_name)
+
     color_list = list(theme["colors"].values())
     color.write_colors(current, color_list)
     sample.create_sample(color_list, files.get_sample_path(current))
+
     set_theme(current, current)
 
 

--- a/wpgtk/data/util.py
+++ b/wpgtk/data/util.py
@@ -1,4 +1,5 @@
 import logging
+import shutil
 import sys
 from subprocess import call
 from colorsys import rgb_to_hls, hls_to_rgb
@@ -57,3 +58,13 @@ def xrdb_merge(file):
 
 def build_key(keyword):
     return "<{}>".format(keyword)
+
+
+def reload_tint2():
+    if shutil.which('tint2'):
+        call(["pkill", "-SIGUSR1", "tint2"])
+
+
+def reload_openbox():
+    if shutil.which('openbox'):
+        call(["openbox", "--reconfigure"])

--- a/wpgtk/data/util.py
+++ b/wpgtk/data/util.py
@@ -29,24 +29,14 @@ def hls_to_hex(hls):
     h, l, s = hls
     r, g, b = hls_to_rgb(h, l, s)
     rgb_int = [max(min(int(elem), 255), 0) for elem in [r, g, b]]
-    rgb_int = tuple(rgb_int)
 
-    hex_result = '%02x%02x%02x' % rgb_int
-    return "#%s" % hex_result
+    return rgb_to_hex(rgb_int)
 
 
-def reduce_brightness(hex_string, amount, sat=0):
+def alter_brightness(hex_string, amount, sat=0):
     h, l, s = hex_to_hls(hex_string)
-    l = max(l - amount, 1)
-    s = max(s - sat, -1)
-
-    return hls_to_hex([h, l, s])
-
-
-def add_brightness(hex_string, amount, sat=0):
-    h, l, s = hex_to_hls(hex_string)
-    l = min(l + amount, 255)
-    s = max(s - sat, -1)
+    l = max(min(l + amount, 255), 1)
+    s = min(max(s - sat, -1), 0)
 
     return hls_to_hex([h, l, s])
 

--- a/wpgtk/gui/color_picker.py
+++ b/wpgtk/gui/color_picker.py
@@ -1,4 +1,4 @@
-from wpgtk.data import util
+from ..data import util
 from gi import require_version
 require_version("Gtk", "3.0")
 require_version("Gdk", "3.0")

--- a/wpgtk/gui/keyword_grid.py
+++ b/wpgtk/gui/keyword_grid.py
@@ -1,5 +1,5 @@
-from wpgtk.data import config
-from wpgtk.data import keyword
+from ..data import config
+from ..data import keyword
 from gi import require_version
 from gi.repository import Gtk
 require_version("Gtk", "3.0")

--- a/wpgtk/gui/option_grid.py
+++ b/wpgtk/gui/option_grid.py
@@ -1,6 +1,6 @@
 from gi.repository import Gtk, Gdk
 from gi import require_version
-from wpgtk.data import config
+from ..data import config
 from pywal import colors
 # making sure it uses v3.0
 require_version("Gtk",  "3.0")

--- a/wpgtk/gui/option_grid.py
+++ b/wpgtk/gui/option_grid.py
@@ -78,6 +78,11 @@ class OptionsGrid(Gtk.Grid):
         self.light_theme_switch.connect("notify::active",
                                         self.on_activate, "light_theme")
         self.lbl_light_theme = Gtk.Label("Use Light Theme")
+        self.wallpaper_switch = Gtk.Switch()
+        self.wallpaper_switch.connect("notify::active",
+                                      self.on_activate,
+                                      "set_wallpaper")
+        self.lbl_wallpaper = Gtk.Label("Set wallpaper:")
 
         # edit cmd
         self.editor_lbl = Gtk.Label("Open optional files with:")
@@ -96,16 +101,23 @@ class OptionsGrid(Gtk.Grid):
         self.load_opt_list()
 
         # Switch Grid attach
-        self.switch_grid.attach(self.lbl_tint2, 1, 1, 3, 1)
-        self.switch_grid.attach(self.tint2_switch, 4, 1, 1, 1)
+        self.switch_grid.attach(self.lbl_wallpaper, 1, 1, 3, 1)
+        self.switch_grid.attach(self.wallpaper_switch, 4, 1, 1, 1)
+
         self.switch_grid.attach(self.lbl_gtk, 5, 1, 3, 1)
         self.switch_grid.attach(self.gtk_switch, 9, 1, 1, 1)
+
         self.switch_grid.attach(self.command_lbl, 1, 2, 3, 1)
         self.switch_grid.attach(self.command_switch, 4, 2, 1, 1)
+
         self.switch_grid.attach(self.lbl_openbox, 5, 2, 3, 1)
         self.switch_grid.attach(self.openbox_switch, 9, 2, 1, 1)
+
         self.switch_grid.attach(self.lbl_light_theme, 1, 3, 3, 1)
         self.switch_grid.attach(self.light_theme_switch, 4, 3, 1, 1)
+
+        self.switch_grid.attach(self.lbl_tint2, 5, 3, 3, 1)
+        self.switch_grid.attach(self.tint2_switch, 9, 3, 1, 1)
 
         # cmd Grid attach
 
@@ -153,6 +165,8 @@ class OptionsGrid(Gtk.Grid):
             .set_editable(config.wpgtk.getboolean("execute_cmd", False))
         self.light_theme_switch\
             .set_active(config.wpgtk.getboolean("light_theme", False))
+        self.wallpaper_switch\
+            .set_active(config.wpgtk.getboolean("set_wallpaper", True))
 
     def combo_box_change(self, combo, *gparam):
         x = combo.get_active()

--- a/wpgtk/gui/template_grid.py
+++ b/wpgtk/gui/template_grid.py
@@ -4,7 +4,8 @@ from gi.repository.GdkPixbuf import Pixbuf
 import os
 from gi import require_version
 from subprocess import Popen
-from wpgtk.data import config, files
+from ..data import config
+from ..data import files
 require_version("Gtk", "3.0")
 
 PAD = 10

--- a/wpgtk/gui/theme_picker.py
+++ b/wpgtk/gui/theme_picker.py
@@ -1,8 +1,12 @@
 import logging
 from gi import require_version
-from . import color_grid, template_grid
-from . import option_grid, keyword_grid
-from wpgtk.data import files, themer, config, color, sample
+from . import color_grid
+from . import template_grid
+from . import option_grid
+from . import keyword_grid
+from ..data import files
+from ..data import themer
+from ..data import config
 from gi.repository import Gtk, GdkPixbuf
 import os
 require_version('Gtk', '3.0')

--- a/wpgtk/misc/wpg.conf
+++ b/wpgtk/misc/wpg.conf
@@ -1,4 +1,5 @@
 [wpgtk]
+set_wallpaper = true
 openbox = true
 gtk = true
 active = 0


### PR DESCRIPTION
In this release I will add support for the many themes @dylanaraps has added to [pywal](https://github.com/dylanaraps/pywal), with the same ability to edit this themes and save them at your leisure that `wpgtk` posseses.

here's a checklist of goals for this release:

- [x] support pywal themes via CLI
- [x] add saturation and brightness globally to theme
  - [x] GUI
  - [x] CLI
- [x] setting wallpaper is optional
  - [x] GUI
  - [x] CLI
- [x] add autocomplete for all new flags
  - [x] --pywal
  - [x] -Ti 
- [x] update README.md