### PR TITLE
smart color sorting - v5.7.0 inbound, read more

### DIFF
--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -11,7 +11,8 @@ from .data import themer
 from .data import color
 from .data import util
 from .data import sample
-from .data import config
+from .data.config import OPT_DIR, WPG_DIR, __version__
+from .data.config import settings
 
 
 def read_args(args):
@@ -149,13 +150,13 @@ def process_arg_errors(args):
 
 def process_args(args):
     if args.light:
-        config.wpgtk["light_theme"] = "true"
+        settings["light_theme"] = "true"
 
     if args.n:
-        config.wpgtk["set_wallpaper"] = "false"
+        settings["set_wallpaper"] = "false"
 
     if args.alpha:
-        config.wpgtk["alpha"] = args.alpha[0]
+        settings["alpha"] = args.alpha[0]
 
     if args.m:
         filename = random.choice(files.get_file_list())
@@ -171,18 +172,18 @@ def process_args(args):
 
     if args.l:
         if args.x:
-            templates = files.get_file_list(config.OPT_DIR, False)
+            templates = files.get_file_list(OPT_DIR, False)
             any(print(t) for t in templates if ".base" in t)
         else:
             print("\n".join(files.get_file_list()))
         exit(0)
 
     if args.t:
-        Popen(["cat", path.join(config.WPG_DIR, "sequences")])
+        Popen(["cat", path.join(WPG_DIR, "sequences")])
         exit(0)
 
     if args.version:
-        print("current version: " + config.__version__)
+        print("current version: " + __version__)
         exit(0)
 
     if args.d:
@@ -261,7 +262,7 @@ def process_args(args):
 
     if args.backend and args.backend != "list":
         if args.backend in pywal.colors.list_backends():
-            config.wpgtk['backend'] = args.backend
+            settings['backend'] = args.backend
         else:
             logging.error("no such backend, please "
                           "choose a valid backend")
@@ -269,7 +270,6 @@ def process_args(args):
 
 
 def main():
-    config.init()
     util.setup_log()
     args = read_args(sys.argv[1:])
     process_arg_errors(args)

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -73,38 +73,35 @@ def write_colors(img, color_list):
     cache_file = files.get_cache_path(img)
 
     pywal.export.color(color_dict, "json", cache_file)
-    pywal.export.color(color_dict,
-                       "xresources",
-                       join(config.XRES_DIR, (img + ".Xres")))
 
 
 def change_colors(colors, which):
     opt = which
 
-    if which in config.FILE_DIC:
-        which = config.FILE_DIC[which]
+    if which in FILE_DIC:
+        which = FILE_DIC[which]
 
-    tmp_filename = which + '.base'
+    tmp_filename = which + ".base"
     try:
-        with open(tmp_filename, 'r') as tmp_file:
+        with open(tmp_filename, "r") as tmp_file:
             first_line = tmp_file.readline()
             tmp_file.seek(0)
             tmp_data = tmp_file.read()
 
-        if 'wpgtk-ignore' not in first_line:
-            for k, v in config.keywords.items():
+        if "wpgtk-ignore" not in first_line:
+            for k, v in keywords.items():
                 tmp_data = tmp_data.replace(util.build_key(k), v)
 
             for k, v in {**colors["wpgtk"], **colors["colors"]}.items():
-                tmp_data = tmp_data.replace(util.build_key(k.upper()), v.strip('#'))
+                tmp_data = tmp_data.replace(util.build_key(k.upper()), v.strip("#"))
 
-            if colors['icons'] and opt == 'icon-step1':
-                for k, v in colors['icons'].items():
-                    tmp_data = tmp_data.replace(k, v.strip('#'))
+            if colors["icons"] and opt == "icon-step1":
+                for k, v in colors["icons"].items():
+                    tmp_data = tmp_data.replace(k, v.strip("#"))
 
-            with open(which, 'w') as target_file:
+            with open(which, "w") as target_file:
                 target_file.write(tmp_data)
-                logging.info("wrote: %s" % opt.split('/').pop())
+                logging.info("wrote: %s" % opt.split("/").pop())
 
     except IOError:
         logging.error("%s - base file does not exist" % opt)

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -42,8 +42,8 @@ def get_color_list(filename, json=False):
 def is_dark_theme(color_list):
     """compare brightness values to see if a color-scheme
     is light or dark"""
-    fg_brightness = util.get_hls_val(color_list[7], 'light')
-    bg_brightness = util.get_hls_val(color_list[0], 'light')
+    fg_brightness = util.get_hls_val(color_list[7], "light")
+    bg_brightness = util.get_hls_val(color_list[0], "light")
 
     return fg_brightness > bg_brightness
 
@@ -109,8 +109,8 @@ def sort_colors(colors):
     corresponding place in the standar xterm colors"""
     colors = colors[:8]
     sorted_by_color = []
-    base_colors = ['#000000', '#ff0000', '#00ff00', '#ffff00',
-                   '#0000ff', '#ff00ff', '#00ffff', '#ffffff']
+    base_colors = ["#000000", "#ff0000", "#00ff00", "#ffff00",
+                   "#0000ff", "#ff00ff", "#00ffff", "#ffffff"]
 
     for y in base_colors:
         cd_tuple = [(x, util.get_distance(x, y)) for i, x in enumerate(colors)]
@@ -139,9 +139,9 @@ def sort_colors(colors):
 def auto_adjust_colors(clist):
     """create a clear foreground and background set of colors
     make a lighter shade of the colorscheme for the last 8 colors"""
-    light = config.wpgtk.getboolean('light_theme', False)
+    light = settings.getboolean("light_theme", False)
 
-    if config.wpgtk.getboolean('auto_sort', True):
+    if settings.getboolean("auto_sort", True):
         clist = sort_colors(clist)
 
     alter_brightness = util.alter_brightness
@@ -161,7 +161,7 @@ def auto_adjust_colors(clist):
     comment = [alter_brightness(clist[0], sign * 20)]
     fg = [alter_brightness(clist[7], sign * 60)]
     clist = clist[:8] + comment \
-        + [alter_brightness(x, sign * get_hls_val(x, 'light') * 0.3, added_sat)
+        + [alter_brightness(x, sign * get_hls_val(x, "light") * 0.3, added_sat)
            for x in clist[1:7]] + fg
 
     return clist
@@ -169,23 +169,23 @@ def auto_adjust_colors(clist):
 
 def add_icon_colors(colors):
     try:
-        glyph = util.alter_brightness(colors['wpgtk']['COLORIN'], -15)
+        glyph = util.alter_brightness(colors["wpgtk"]["COLORIN"], -15)
         icon_dic = {}
 
-        with open(config.FILE_DIC['icon-step1'], "r") as icon_file:
+        with open(FILE_DIC["icon-step1"], "r") as icon_file:
             for line in icon_file:
-                if('glyphColorNew=' in line):
-                    icon_dic['oldglyph'] = line.split('=')[1].strip('\n')
+                if("glyphColorNew=" in line):
+                    icon_dic["oldglyph"] = line.split("=")[1].strip("\n")
 
-                if('frontColorNew=' in line):
-                    icon_dic['oldfront'] = line.split('=')[1].strip('\n')
+                if("frontColorNew=" in line):
+                    icon_dic["oldfront"] = line.split("=")[1].strip("\n")
 
-                if('backColorNew=' in line):
-                    icon_dic['oldback'] = line.split('=')[1].strip('\n')
+                if("backColorNew=" in line):
+                    icon_dic["oldback"] = line.split("=")[1].strip("\n")
 
-        icon_dic['newglyph'] = glyph
-        icon_dic['newfront'] = colors['wpgtk']['COLORACT']
-        icon_dic['newback'] = colors['wpgtk']['COLORIN']
+        icon_dic["newglyph"] = glyph
+        icon_dic["newfront"] = colors["wpgtk"]["COLORACT"]
+        icon_dic["newback"] = colors["wpgtk"]["COLORIN"]
 
         return icon_dic
 
@@ -226,14 +226,14 @@ def split_active(hexc, is_dark_theme=True):
 
 def add_wpgtk_colors(cdic):
     """ensamble wpgtk color dictionary"""
-    index = config.wpgtk.getint("active")
+    index = settings.getint("active")
     index = index if index > 0 else randint(9, 14)
 
-    base_color = cdic['colors']['color%s' % index]
+    base_color = cdic["colors"]["color%s" % index]
 
-    color_list = [cdic['colors']['color%s' % i] for i in range(16)]
-    cdic['wpgtk'] = split_active(base_color, is_dark_theme(color_list))
-    cdic['icons'] = add_icon_colors(cdic)
+    color_list = [cdic["colors"]["color%s" % i] for i in range(16)]
+    cdic["wpgtk"] = split_active(base_color, is_dark_theme(color_list))
+    cdic["icons"] = add_icon_colors(cdic)
 
     return cdic
 
@@ -241,17 +241,17 @@ def add_wpgtk_colors(cdic):
 def apply_colorscheme(colors):
     colors = add_wpgtk_colors(colors)
 
-    if isfile(config.FILE_DIC['icon-step2']):
-        change_colors(colors, 'icon-step1')
-        Popen(config.FILE_DIC['icon-step2'])
+    if os.path.isfile(FILE_DIC["icon-step2"]):
+        change_colors(colors, "icon-step1")
+        Popen(FILE_DIC["icon-step2"])
 
     change_templates(colors)
 
-    if config.wpgtk.getboolean('tint2'):
+    if settings.getboolean("tint2"):
         util.reload_tint2()
 
-    if config.wpgtk.getboolean('openbox'):
+    if settings.getboolean("openbox"):
         util.reload_openbox()
 
-    if config.wpgtk.getboolean('gtk'):
+    if settings.getboolean("gtk"):
         pywal.reload.gtk()

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -154,12 +154,7 @@ def auto_adjust_colors(clist):
     added_sat = 0.25 if light else 0.1
     sign = -1 if light else 1
 
-    # convert dark to light or the other way around
     if light == is_dark_theme(clist):
-        sat_diff = -0.1 if light else 0.1
-        clist = [clist[0]] \
-            + [alter_brightness(x, 0, sat_diff) for x in clist[1:7]] \
-            + clist[7:]
         clist[7], clist[0] = clist[0], clist[7]
 
     comment = [alter_brightness(clist[0], sign * 20)]

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -145,7 +145,7 @@ def auto_adjust_colors(clist):
     make a lighter shade of the colorscheme for the last 8 colors"""
     light = settings.getboolean("light_theme", False)
 
-    if settings.getboolean("auto_sort", True):
+    if settings.getboolean("smart_sort", True):
         clist = sort_colors(clist)
 
     alter_brightness = util.alter_brightness

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -1,12 +1,13 @@
 import sys
 import logging
 import pywal
+import os
 from operator import itemgetter
 from subprocess import Popen
-from random import shuffle
-from os.path import join, isfile
-from random import randint
-from . import config
+from random import shuffle, randint
+
+from .config import settings, keywords
+from .config import WALL_DIR, WPG_DIR, FILE_DIC, OPT_DIR
 from . import files
 from . import util
 from . import sample

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -108,7 +108,7 @@ def change_colors(colors, which):
         logging.error("%s - base file does not exist" % opt)
 
 
-def sort_colors(colors):
+def smart_sort(colors):
     """automatically set the most look-alike colors to their
     corresponding place in the standar xterm colors"""
     colors = colors[:8]
@@ -119,7 +119,6 @@ def sort_colors(colors):
     for y in base_colors:
         cd_tuple = [(x, util.get_distance(x, y)) for i, x in enumerate(colors)]
         cd_tuple.sort(key=itemgetter(1))
-
         sorted_by_color.append(cd_tuple)
 
     i = 0
@@ -141,12 +140,11 @@ def sort_colors(colors):
 
 
 def auto_adjust_colors(clist):
-    """create a clear foreground and background set of colors
-    make a lighter shade of the colorscheme for the last 8 colors"""
+    """create a clear foreground and background set of colors"""
     light = settings.getboolean("light_theme", False)
 
     if settings.getboolean("smart_sort", True):
-        clist = sort_colors(clist)
+        clist = smart_sort(clist)
 
     alter_brightness = util.alter_brightness
     get_hls_val = util.get_hls_val

--- a/wpgtk/data/config.py
+++ b/wpgtk/data/config.py
@@ -1,14 +1,11 @@
 import configparser
 import shutil
 import os
-
 import logging
 
-__version__ = '5.5.4'
+__version__ = '5.6.0'
 
-settings = None
-wpgtk = None
-keywords = None
+parser = None
 
 HOME = os.path.expanduser("~")
 WPG_DIR = os.path.join(HOME, ".config/wpg")
@@ -16,54 +13,52 @@ CONF_FILE = os.path.join(WPG_DIR, "wpg.conf")
 MODULE_DIR = os.path.abspath(os.path.join(__file__, "../../"))
 CONF_BACKUP = os.path.join(MODULE_DIR, "misc/wpg.conf")
 WALL_DIR = os.path.join(WPG_DIR, "wallpapers")
-SAMPLE_DIR = os.path.join(WALL_DIR, "sample")
-XRES_DIR = os.path.join(WALL_DIR, "xres")
-CSS_DIR = os.path.join(WALL_DIR, "css")
-SHELL_DIR = os.path.join(WALL_DIR, "shell")
-SCHEME_DIR = os.path.join(WALL_DIR, "schemes")
+SAMPLE_DIR = os.path.join(WPG_DIR, "samples")
+SCHEME_DIR = os.path.join(WPG_DIR, "schemes")
+FORMAT_DIR = os.path.join(WPG_DIR, "formats")
 OPT_DIR = os.path.join(WPG_DIR, "templates")
-
-RCC = []  # random color cache
-
-
-FILE_DIC = {'templates':  os.path.join(HOME, ".config/wpg/templates"),
-            'icon-step1': os.path.join(HOME, ".icons/flattrcolor/scripts"
-                                             "/replace_folder_file.sh"),
-            'icon-step2': os.path.join(HOME, ".icons/flattrcolor/scripts"
-                                             "/replace_script.sh")}
+FILE_DIC = {
+    'icon-step1': os.path.join(HOME, ".icons/flattrcolor/scripts"
+                               "/replace_folder_file.sh"),
+    'icon-step2': os.path.join(HOME, ".icons/flattrcolor/scripts"
+                               "/replace_script.sh")
+}
 
 
 def write_conf(config_path=CONF_FILE):
-    global settings
+    global parser
+
     with open(config_path, 'w') as config_file:
-        settings.write(config_file)
+        parser.write(config_file)
 
 
 def load_sections():
-    global settings
-    global wpgtk
-    global keywords
-    settings = configparser.ConfigParser()
-    settings.optionxform = str
-    settings.read(CONF_FILE)
-    wpgtk = settings['wpgtk']
-    keywords = settings['keywords']
+    """reads the sections of the config file"""
+    global parser
+
+    parser = configparser.ConfigParser()
+    parser.optionxform = str
+    parser.read(CONF_FILE)
+
+    return [parser['settings'], parser['keywords']]
 
 
-def init():
+def load_settings():
+    if not os.path.isdir(FORMAT_DIR):
+        logging.info('creating dirs...')
+        os.makedirs(SAMPLE_DIR, exist_ok=True)
+        os.makedirs(SCHEME_DIR, exist_ok=True)
+        os.makedirs(FORMAT_DIR, exist_ok=True)
+        os.makedirs(OPT_DIR, exist_ok=True)
+
     try:
-        if not os.path.isdir(SCHEME_DIR):
-            logging.info('creating dirs...')
-            os.makedirs(XRES_DIR, exist_ok=True)
-            os.makedirs(SAMPLE_DIR, exist_ok=True)
-            os.makedirs(SCHEME_DIR, exist_ok=True)
-            os.makedirs(OPT_DIR, exist_ok=True)
-        load_sections()
-        return 0
-    except:
+        return load_sections()
+    except Exception:
         logging.error("not a valid config file")
         logging.info("copying default config file")
-        pass
 
-    shutil.copy(CONF_BACKUP, CONF_FILE)
-    load_sections()
+        shutil.copy(CONF_BACKUP, CONF_FILE)
+        return load_sections()
+
+
+settings, keywords = load_settings()

--- a/wpgtk/data/config.py
+++ b/wpgtk/data/config.py
@@ -3,7 +3,7 @@ import shutil
 import os
 import logging
 
-__version__ = '5.6.0'
+__version__ = '5.7.0'
 
 parser = None
 

--- a/wpgtk/data/files.py
+++ b/wpgtk/data/files.py
@@ -98,8 +98,7 @@ def delete_template(basefile):
 
 
 def delete_colorschemes(wallpaper):
-    """delete all colorschemes related to the given
-    wallpaper"""
+    """delete all colorschemes related to the given wallpaper"""
     for backend in list_backends():
         try:
             os.remove(get_cache_path(wallpaper, backend))
@@ -109,7 +108,6 @@ def delete_colorschemes(wallpaper):
 
 
 def change_current(filename):
-    os.symlink(join(config.WALL_DIR, filename),
-               join(config.WPG_DIR, ".currentTmp"))
-    os.rename(join(config.WPG_DIR, ".currentTmp"),
-              join(config.WPG_DIR, ".current"))
+    """update symlink to point to the current wallpaper"""
+    os.symlink(join(WALL_DIR, filename), join(WPG_DIR, ".currentTmp"))
+    os.rename(join(WPG_DIR, ".currentTmp"), join(WPG_DIR, ".current"))

--- a/wpgtk/data/files.py
+++ b/wpgtk/data/files.py
@@ -2,33 +2,21 @@ import os
 import shutil
 import re
 import logging
-from . import config
 from pywal.colors import cache_fname, list_backends
+
+from .config import settings, WALL_DIR, WPG_DIR, OPT_DIR, SAMPLE_DIR
 from os.path import join
 
 
-def get_file_list(path=config.WALL_DIR, images=True, json=False):
+def get_file_list(path=WALL_DIR, images=True):
     """gets filenames in a given directory, optional
-    parameters for image exclusiveness
-
-    @param path: directory to look for, default wallpaper dir
-    @type  :  Optional string
-
-    @param images: wether to show only images or all files
-    @type  :  Optional boolean
-
-    @return:  A list with the directories file names
-    @rtype :  List
-    """
+    parameters for image filter."""
     valid = re.compile(r"^[^\.](.*\.png$|.*\.jpg$|.*\.jpeg$|.*\.jpe$)")
     files = []
 
-    for (dirpath, dirnames, filenames) in os.walk(path):
-        for f in filenames:
-            files.append(f)
+    for (_, _, filenames) in os.walk(path):
+        files.extend(filenames)
         break
-
-    files.sort()
 
     if images:
         return [elem for elem in files if valid.fullmatch(elem)]
@@ -39,10 +27,10 @@ def get_file_list(path=config.WALL_DIR, images=True, json=False):
 def get_cache_path(wallpaper, backend=None):
     """get a colorscheme cache path using a wallpaper name"""
     if not backend:
-        backend = config.wpgtk.get('backend', 'wal')
+        backend = settings.get('backend', 'wal')
 
-    filepath = join(config.WALL_DIR, wallpaper)
-    filename = cache_fname(filepath, backend, False, config.WALL_DIR)
+    filepath = join(WALL_DIR, wallpaper)
+    filename = cache_fname(filepath, backend, False, WPG_DIR)
 
     return join(*filename)
 
@@ -50,11 +38,11 @@ def get_cache_path(wallpaper, backend=None):
 def get_sample_path(wallpaper, backend=None):
     """gets a wallpaper colorscheme sample's path"""
     if not backend:
-        backend = config.wpgtk.get('backend', 'wal')
+        backend = settings.get('backend', 'wal')
 
     sample_filename = "%s_%s_sample.png" % (wallpaper, backend)
 
-    return join(config.SAMPLE_DIR, sample_filename)
+    return join(SAMPLE_DIR, sample_filename)
 
 
 def add_template(cfile, bfile=None):
@@ -73,8 +61,8 @@ def add_template(cfile, bfile=None):
         shutil.copy2(cfile, cfile + ".bak")
         src_file = bfile if bfile else cfile
 
-        shutil.copy2(src_file, join(config.OPT_DIR, template_name))
-        os.symlink(cfile, join(config.OPT_DIR,
+        shutil.copy2(src_file, join(OPT_DIR, template_name))
+        os.symlink(cfile, join(OPT_DIR,
                    template_name.replace(".base", "")))
 
         logging.info("created backup %s.bak" % cfile)
@@ -86,7 +74,7 @@ def add_template(cfile, bfile=None):
 def delete_template(basefile):
     """delete a template in wpgtk with the given
     base file name"""
-    base_file = join(config.OPT_DIR, basefile)
+    base_file = join(OPT_DIR, basefile)
     conf_file = base_file.replace(".base", "")
 
     try:

--- a/wpgtk/data/keywords.py
+++ b/wpgtk/data/keywords.py
@@ -1,35 +1,41 @@
-from . import config
+from .config import keywords, write_conf
 
 KEY_LENGTH = 5
 VAL_LENGTH = 2
 
 
 def update_keyword(old_keyword, new_keyword, save=False):
+    """validates and updates a keyword"""
     if(len(new_keyword) < KEY_LENGTH):
         raise Exception('Keyword must be longer than 5 characters')
-    config.keywords[new_keyword] = config.keywords[old_keyword]
+
+    keywords[new_keyword] = keywords[old_keyword]
+
     if(old_keyword != new_keyword):
-        config.keywords.pop(old_keyword, None)
+        keywords.pop(old_keyword, None)
 
     if save:
-        config.write_conf()
+        write_conf()
 
 
 def update_value(keyword, value, save=False):
     if(len(value) < 2):
         raise Exception('Value must be longer than 3 characters')
-    config.keywords[keyword] = value
+
+    keywords[keyword] = value
 
     if save:
-        config.write_conf()
+        write_conf()
 
 
 def create_pair(keyword, value, save=False):
     if(len(value) < VAL_LENGTH):
         raise Exception('Value must be longer than 3 characters')
+
     if(len(keyword) < KEY_LENGTH):
         raise Exception('Value must be longer than 3 characters')
-    config.keywords[keyword] = value
+
+    keywords[keyword] = value
 
     if save:
-        config.write_conf()
+        write_conf()

--- a/wpgtk/data/sample.py
+++ b/wpgtk/data/sample.py
@@ -1,18 +1,17 @@
 import os
-from . import config
+import pywal
+
+from .config import WALL_DIR
 
 try:
     import Image
 except ImportError:
     from PIL import Image
 
-import pywal
 
-
-def create_sample(colors, f=os.path.join(config.WALL_DIR, ".tmp.sample.png")):
+def create_sample(colors, f=os.path.join(WALL_DIR, ".tmp.sample.png")):
     im = Image.new("RGB", (480, 50), "white")
     pix = im.load()
-
     width_sample = im.size[0]//(len(colors)//2)
 
     for i, c in enumerate(colors[:8]):
@@ -24,4 +23,5 @@ def create_sample(colors, f=os.path.join(config.WALL_DIR, ".tmp.sample.png")):
         for j in range(width_sample*i, width_sample*i+width_sample):
             for k in range(25, 50):
                 pix[j, k] = pywal.util.hex_to_rgb(c)
+
     im.save(f)

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -4,8 +4,9 @@ import logging
 from os.path import realpath
 from os import remove, path, symlink
 from subprocess import Popen
+
+from .config import WPG_DIR, WALL_DIR, FORMAT_DIR, HOME, settings
 from . import color
-from . import config
 from . import files
 from . import util
 from . import sample

--- a/wpgtk/gui/color_grid.py
+++ b/wpgtk/gui/color_grid.py
@@ -1,11 +1,13 @@
 import os
 import shutil
 import pywal
+
+from ..data.config import WALL_DIR
 from ..data import color
 from ..data import util
-from ..data import config
 from ..data import files
 from ..data import sample
+
 from .color_picker import ColorDialog
 from gi import require_version
 from gi.repository import Gtk, Gdk, GdkPixbuf
@@ -76,7 +78,7 @@ class ColorGrid(Gtk.Grid):
                 self.colorgrid.attach(self.button_list[cont], x, y + 1, 1, 1)
                 cont += 1
 
-        sample_name = os.path.join(config.WALL_DIR, ".no_sample.sample.png")
+        sample_name = os.path.join(WALL_DIR, ".no_sample.sample.png")
         self.sample = Gtk.Image()
         if(os.path.isfile(sample_name)):
             self.pixbuf_sample = GdkPixbuf.Pixbuf.new_from_file_at_size(
@@ -159,7 +161,7 @@ class ColorGrid(Gtk.Grid):
         self.render_sample()
 
     def render_sample(self):
-        sample_path = os.path.join(config.WALL_DIR, ".tmp.sample.png")
+        sample_path = os.path.join(WALL_DIR, ".tmp.sample.png")
         self.pixbuf_sample = GdkPixbuf.Pixbuf.new_from_file_at_size(
                 str(sample_path),
                 width=500,
@@ -178,9 +180,9 @@ class ColorGrid(Gtk.Grid):
         if len(current_walls) > 0:
             x = self.option_combo.get_active()
             color.write_colors(current_walls[x], self.color_list)
-            tmpfile = os.path.join(config.WALL_DIR, ".tmp.sample.png")
+            tmpfile = os.path.join(WALL_DIR, ".tmp.sample.png")
             if(os.path.isfile(tmpfile)):
-                shutil.move(os.path.join(config.WALL_DIR, ".tmp.sample.png"),
+                shutil.move(os.path.join(WALL_DIR, ".tmp.sample.png"),
                             files.get_sample_path(current_walls[x]))
                 self.done_lbl.set_text("Changes saved")
                 x = self.parent.colorscheme.get_active()

--- a/wpgtk/gui/keyword_grid.py
+++ b/wpgtk/gui/keyword_grid.py
@@ -1,5 +1,4 @@
-from ..data import config
-from ..data import keywords
+from ..data.config import keywords, write_conf
 from gi import require_version
 from gi.repository import Gtk
 require_version("Gtk", "3.0")
@@ -64,7 +63,7 @@ class KeywordGrid(Gtk.Grid):
         for path in pathlist:
             tree_iter = m.get_iter(path)
             value = m.get_value(tree_iter, 0)
-            config.keywords.pop(value, None)
+            keywords.pop(value, None)
             self.reload_keyword_list()
 
     def text_edited(self, widget, path, text, col):
@@ -83,11 +82,11 @@ class KeywordGrid(Gtk.Grid):
 
     def reload_keyword_list(self):
         self.liststore.clear()
-        for k, v in config.keywords.items():
+        for k, v in keywords.items():
             self.liststore.append([k, v])
 
     def save_keywords(self, widget):
-        config.write_conf()
+        write_conf()
         self.status_lbl.set_text('Saved')
 
     def append_new_keyword(self, widget):

--- a/wpgtk/gui/option_grid.py
+++ b/wpgtk/gui/option_grid.py
@@ -1,6 +1,6 @@
 from gi.repository import Gtk, Gdk
 from gi import require_version
-from ..data import config
+from ..data.config import settings, write_conf
 from pywal import colors
 # making sure it uses v3.0
 require_version("Gtk",  "3.0")
@@ -152,53 +152,53 @@ class OptionsGrid(Gtk.Grid):
     def on_activate(self,  switch,  *gparam):
         if(gparam[1] == 'execute_cmd'):
             self.command_txt.set_editable(switch.get_active())
-        config.wpgtk[gparam[1]] = str(switch.get_active()).lower()
+        settings[gparam[1]] = str(switch.get_active()).lower()
         self.lbl_save.set_text('')
 
     def load_opt_list(self):
-        current_backend = config.wpgtk.get("backend", "wal")
+        current_backend = settings.get("backend", "wal")
         i = self.backend_list.index(current_backend)
         self.backend_combo.set_active(i)
 
         self.color_combo\
-            .set_active(config.wpgtk.getint("active", 0))
+            .set_active(settings.getint("active", 0))
 
         self.gtk_switch\
-            .set_active(config.wpgtk.getboolean("gtk", True))
+            .set_active(settings.getboolean("gtk", True))
         self.tint2_switch\
-            .set_active(config.wpgtk.getboolean("tint2", True))
+            .set_active(settings.getboolean("tint2", True))
         self.command_switch\
-            .set_active(config.wpgtk.getboolean("execute_cmd", False))
+            .set_active(settings.getboolean("execute_cmd", False))
         self.openbox_switch\
-            .set_active(config.wpgtk.getboolean("openbox", True))
+            .set_active(settings.getboolean("openbox", True))
         self.light_theme_switch\
-            .set_active(config.wpgtk.getboolean("light_theme", False))
+            .set_active(settings.getboolean("light_theme", False))
         self.wallpaper_switch\
-            .set_active(config.wpgtk.getboolean("set_wallpaper", True))
+            .set_active(settings.getboolean("set_wallpaper", True))
 
         self.editor_txt\
-            .set_text(config.wpgtk.get("editor", "urxvt -e vim"))
+            .set_text(settings.get("editor", "urxvt -e vim"))
         self.command_txt\
-            .set_text(config.wpgtk.get("command", "yes hi"))
+            .set_text(settings.get("command", "yes hi"))
         self.command_txt\
-            .set_editable(config.wpgtk.getboolean("execute_cmd", False))
+            .set_editable(settings.getboolean("execute_cmd", False))
         self.alpha_txt\
-            .set_text(config.wpgtk.get("alpha", "100"))
+            .set_text(settings.get("alpha", "100"))
 
     def combo_box_change(self, combo, *gparam):
         x = combo.get_active()
         if(gparam[0] == "active"):
-            config.wpgtk[gparam[0]] = str(x)
+            settings[gparam[0]] = str(x)
             color = Gdk.color_parse(self.parent.cpage.color_list[x])
             self.color_button.modify_bg(Gtk.StateType.NORMAL,  color)
         else:
-            config.wpgtk[gparam[0]] = self.backend_list[x]
+            settings[gparam[0]] = self.backend_list[x]
         self.lbl_save.set_text("")
 
     def on_txt_change(self, gtk_entry, *gparam):
-        config.wpgtk[gparam[0]] = gtk_entry.get_text()
+        settings[gparam[0]] = gtk_entry.get_text()
         self.lbl_save.set_text("")
 
     def on_save_button(self,  button):
-        config.write_conf()
+        write_conf()
         self.lbl_save.set_text("Saved")

--- a/wpgtk/gui/option_grid.py
+++ b/wpgtk/gui/option_grid.py
@@ -86,7 +86,13 @@ class OptionsGrid(Gtk.Grid):
         self.wallpaper_switch.connect("notify::active",
                                       self.on_activate,
                                       "set_wallpaper")
-        self.lbl_wallpaper = Gtk.Label("Set wallpaper:")
+        self.lbl_wallpaper = Gtk.Label("Set wallpaper")
+
+        self.smart_sort_switch = Gtk.Switch()
+        self.smart_sort_switch.connect("notify::active",
+                                       self.on_activate,
+                                       "smart_sort")
+        self.lbl_smart_sort = Gtk.Label("Use smart sort")
 
         # edit cmd
         self.editor_lbl = Gtk.Label("Open optional files with:")
@@ -126,6 +132,9 @@ class OptionsGrid(Gtk.Grid):
         self.switch_grid.attach(self.lbl_tint2, 5, 3, 3, 1)
         self.switch_grid.attach(self.tint2_switch, 9, 3, 1, 1)
 
+        self.switch_grid.attach(self.lbl_smart_sort, 1, 4, 3, 1)
+        self.switch_grid.attach(self.smart_sort_switch, 4, 4, 1, 1)
+
         # cmd Grid attach
 
         # Active Grid attach
@@ -162,7 +171,6 @@ class OptionsGrid(Gtk.Grid):
 
         self.color_combo\
             .set_active(settings.getint("active", 0))
-
         self.gtk_switch\
             .set_active(settings.getboolean("gtk", True))
         self.tint2_switch\
@@ -175,6 +183,8 @@ class OptionsGrid(Gtk.Grid):
             .set_active(settings.getboolean("light_theme", False))
         self.wallpaper_switch\
             .set_active(settings.getboolean("set_wallpaper", True))
+        self.smart_sort_switch\
+            .set_active(settings.getboolean("smart_sort", True))
 
         self.editor_txt\
             .set_text(settings.get("editor", "urxvt -e vim"))

--- a/wpgtk/gui/template_grid.py
+++ b/wpgtk/gui/template_grid.py
@@ -1,11 +1,13 @@
 import logging
+import os
+
+from subprocess import Popen
+from ..data.config import OPT_DIR, settings
+from ..data import files
+
 from gi.repository import Gtk
 from gi.repository.GdkPixbuf import Pixbuf
-import os
 from gi import require_version
-from subprocess import Popen
-from ..data import config
-from ..data import files
 require_version("Gtk", "3.0")
 
 PAD = 10
@@ -54,7 +56,7 @@ class TemplateGrid(Gtk.Grid):
         self.scroll.add(self.file_view)
 
         self.item_names = [filen for filen in
-                           files.get_file_list(config.OPT_DIR, False)
+                           files.get_file_list(OPT_DIR, False)
                            if '.base' in filen]
 
         for filen in self.item_names:
@@ -86,7 +88,7 @@ class TemplateGrid(Gtk.Grid):
             for f in filechooser.get_filenames():
                 files.add_template(f)
             self.item_names = [f for f in
-                               files.get_file_list(config.OPT_DIR, False)
+                               files.get_file_list(OPT_DIR, False)
                                if '.base' in f]
             self.liststore = Gtk.ListStore(Pixbuf, str)
             for filen in self.item_names:
@@ -99,8 +101,8 @@ class TemplateGrid(Gtk.Grid):
     def on_open_clicked(self, widget):
         if self.current is not None:
             item = self.item_names[self.current]
-            args_list = config.wpgtk['editor'].split(' ')
-            args_list.append(os.path.join(config.OPT_DIR, item))
+            args_list = settings['editor'].split(' ')
+            args_list.append(os.path.join(OPT_DIR, item))
             try:
                 Popen(args_list)
             except Exception as e:

--- a/wpgtk/gui/theme_picker.py
+++ b/wpgtk/gui/theme_picker.py
@@ -1,14 +1,16 @@
 import logging
-from gi import require_version
+import os
+
 from . import color_grid
 from . import template_grid
 from . import option_grid
 from . import keyword_grid
 from ..data import files
 from ..data import themer
-from ..data import config
+from ..data.config import WALL_DIR, WPG_DIR, __version__
+
+from gi import require_version
 from gi.repository import Gtk, GdkPixbuf
-import os
 require_version('Gtk', '3.0')
 
 PAD = 10
@@ -17,9 +19,9 @@ PAD = 10
 class mainWindow(Gtk.Window):
 
     def __init__(self, args):
-        Gtk.Window.__init__(self, title='wpgtk ' + config.__version__)
+        Gtk.Window.__init__(self, title='wpgtk ' + __version__)
 
-        image_name = os.path.join(config.WPG_DIR, '.current')
+        image_name = os.path.join(WPG_DIR, '.current')
         image_name = os.path.realpath(image_name)
         self.set_default_size(200, 200)
         self.args = args
@@ -159,7 +161,7 @@ class mainWindow(Gtk.Window):
         x = self.option_combo.get_active()
         self.colorscheme.set_active(x)
         selected_file = files.get_file_list()[x]
-        filepath = os.path.join(config.WALL_DIR, selected_file)
+        filepath = os.path.join(WALL_DIR, selected_file)
 
         self.pixbuf_preview = GdkPixbuf.Pixbuf.new_from_file_at_scale(
             str(filepath),

--- a/wpgtk/misc/wpg-install.sh
+++ b/wpgtk/misc/wpg-install.sh
@@ -8,7 +8,7 @@ COLOR_OTHER="${HOME}/.config/wpg/templates";
 #         NAME:  wpg-install.sh
 #  DESCRIPTION:  Installs various wpgtk themes.
 #===============================================================================
-function usage ()
+usage()
 {
   echo "Usage :  $0 [options] [--]
 
@@ -22,11 +22,12 @@ function usage ()
   -r   Install rofi template
   -I   Install i3 template
   -p   Install polybar template
+  -b   Install bspwm template
   -H   Specify hash of wpgtk-templates repository to use
   "
 }
 
-function checkprogram ()
+checkprogram()
 {
   command -v $1 >/dev/null 2>&1;
   if [[ $? -eq 1 ]]; then
@@ -35,7 +36,7 @@ function checkprogram ()
   fi
 }
 
-function getfiles ()
+getfiles()
 {
   checkprogram 'git';
   checkprogram 'wpg';
@@ -51,7 +52,7 @@ function getfiles ()
   fi
 }
 
-function install_tint2 ()
+install_tint2()
 {
   echo -n "This might override your tint2 config, Continue?[Y/n]: ";
   read -r response;
@@ -68,7 +69,7 @@ function install_tint2 ()
   echo ":: tint2 template not installed";
 }
 
-function install_rofi ()
+install_rofi()
 {
   echo -n "This might override your rofi config, Continue?[Y/n]: ";
   read -r response;
@@ -85,7 +86,7 @@ function install_rofi ()
   echo ":: rofi template not installed";
 }
 
-function install_i3 () 
+install_i3() 
 {
   echo -n "This might override your i3 config, Continue?[Y/n]: ";
   read -r response;
@@ -102,7 +103,7 @@ function install_i3 ()
   echo ":: i3 template not installed";
 }
 
-function install_polybar () 
+install_polybar() 
 {
   echo -n "This might override your polybar config, Continue?[Y/n]: ";
   read -r response;
@@ -119,7 +120,7 @@ function install_polybar ()
   echo ":: polybar template not installed";
 }
 
-function install_gtk ()
+install_gtk()
 {
   echo "Installing gtk themes";
   cp -r ./FlatColor "${HOME}/.themes/" && \
@@ -135,14 +136,14 @@ function install_gtk ()
   echo ":: FlatColor gtk themes install done."
 }
 
-function install_icons()
+install_icons()
 {
   echo "Installing icon pack";
   cp -r flattrcolor "${HOME}/.icons/" && \
     echo ":: flattr icons install done."
 }
 
-function install_openbox()
+install_openbox()
 {
   echo "Installing openbox themes";
   cp --remove-destination -r ./openbox/colorbamboo/* "${HOME}/.themes/colorbamboo"
@@ -153,7 +154,17 @@ function install_openbox()
   fi
 }
 
-function clean_up()
+install_bspwm()
+{
+  echo "Installing bspwm colors";
+  mv "./bspwm/bspwm_colors.base" "${COLOR_OTHER}/bspwm_colors.base";
+  mv "./bspwm/bspwm_colors" "${COLOR_OTHER}/bspwm_colors";
+  ln -sf "${HOME}/.config/bspwm/bspwm_colors.sh" "${COLOR_OTHER}/bspwm_colors" && \
+	echo 'bash "$HOME/.config/bspwm/bspwm_colors.sh" &' >> "${HOME}/.config/bspwm/bspwmrc";
+  echo ":: bspwm colors install done.";
+}
+
+clean_up()
 {
   rm -rf "$THEME_DIR";
 }
@@ -163,9 +174,9 @@ function clean_up()
 #  Handle command line arguments
 #-----------------------------------------------------------------------
 
-function getargs()
+getargs()
 {
-  while getopts "H:hvotgiIpr" opt
+  while getopts "H:bhvotgiIpr" opt
   do
     case $opt in
       h)
@@ -183,6 +194,7 @@ function getargs()
       r)    rofi="true" ;;
       I)      i3="true" ;;
       p) polybar="true" ;;
+	  b)   bspwm="true" ;;
       H) commit="${OPTARG}" ;;
       *)
         echo -e "\n  Option does not exist : $OPTARG\n"
@@ -195,7 +207,7 @@ function getargs()
     shift "$((OPTIND - 1))"
 }
 
-function main()
+main()
 {
   getargs "$@";
   getfiles;
@@ -206,6 +218,7 @@ function main()
   [[ "$icons" == "true" ]] && install_icons;
   [[ "$polybar" == "true" ]] && install_polybar;
   [[ "$i3" == "true" ]] && install_i3;
+  [[ "$bspwm" == "true" ]] && install_bspwm;
   clean_up;
 }
 

--- a/wpgtk/misc/wpg.conf
+++ b/wpgtk/misc/wpg.conf
@@ -1,4 +1,4 @@
-[wpgtk]
+[settings]
 set_wallpaper = true
 openbox = true
 gtk = true
@@ -9,5 +9,7 @@ editor = urxvt -e vim
 execute_cmd = false
 command = urxvt -e echo hi
 backend = wal
+alpha = 100
+auto_sort = true
 
 [keywords]


### PR DESCRIPTION
This PR started as a solution to: https://github.com/deviantfero/wpgtk/issues/99, in which users need to have a set place for each color, that is to say, green always go where green goes, yellow where yellow goes and so on, this is done according to the standard terminal colors order, which is the following:

`black, red, green, yellow, blue, magenta, cyan, white`

when you use the `auto-adjust` functions, the colors will also be sorted in this fashion, if you want to disable this functionality you can do so via the `smart_sort` setting in the configuration file, you can also disable that from the GUI.

**Other changes include:**
* Folder structure changed

```sh
# new layout
.config/wpg
├── formats
├── samples
├── schemes
├── sequences
├── templates
├── wallpapers
├── wpg.conf
└── wp_init.sh

```
* in formats, all templates supported by `pywal` will be exported for the current wallpaper, yes this includes user defined pywal templates
* as always you can also use your own `wpgtk` templates too
* more documentation in general
* new option in config file `alpha` to set transparency value for `urxvt`.