### PR TITLE
Change how wpgtk checks version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,14 @@
+# -*- coding: utf8 -*-
 """wpgtk - setup.py"""
 import os
 import setuptools
+import sys
 
-try:
-    import wpgtk
-except (ImportError, SyntaxError):
+if sys.version_info.major < 3 or sys.version_info.minor < 5:
     print("error: wpgtk requires Python 3.5 or greater.")
     quit(1)
 
+import wpgtk
 
 try:
     LONG_DESC = open('README.md').read()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 import sys
 
 if sys.version_info.major < 3 or sys.version_info.minor < 5:
-    print("error: wpgtk requires Python 3.5 or greater.")
+    print("error: wpgtk requires Python 3.5 or greater.", file=sys.stderr)
     quit(1)
 
 import wpgtk


### PR DESCRIPTION
Changes how wpgtk checks the current running Python version in setup.py to use `sys.version_info` rather than doing a try/except wrapped around importing the main module.