### PR TITLE
New template format

### DIFF
--- a/completions/bash/wpg
+++ b/completions/bash/wpg
@@ -2,7 +2,7 @@ function _wpg() {
     local optforprofiles
     _get_comp_words_by_ref cur
     # themes
-    optforprofiles="-s -e -d -z -m -LA -A --brt --sat"
+    optforprofiles="-s -e -d -z -m -LA -A --brt --sat -R"
     # themes, pywal themes
 	optforvariabletheme="-Ti"
     # themes, filenames

--- a/completions/bash/wpg
+++ b/completions/bash/wpg
@@ -1,14 +1,14 @@
 function _wpg() {
-    local optforprofiles
+    local optforcolorschemes
     _get_comp_words_by_ref cur
     # themes
-    optforprofiles="-s -e -d -z -m -LA -A --brt --sat -R"
+    optforcolorschemes="-s -e -d -z -m -LA -A --brt --sat -R"
     # themes, pywal themes
 	optforvariabletheme="-Ti"
     # themes, filenames
     optvariable="-i -o"
 	# filenames
-    optfordefault="--link -aL -La -a -ta -at"
+    optfordefault="--link -aL -La -a -ta -at --update"
 	# templates
     optfortemplates="-td -dt"
 	# pywal backends
@@ -19,7 +19,7 @@ function _wpg() {
     if [[ $COMP_CWORD = 1 ]]; then
         COMPREPLY=($(compgen -W "$(_parse_usage wpg)" -- "$cur"))
     elif [[ $COMP_CWORD < 4 || ${COMP_WORDS[1]} != "-s" ]]; then
-        for opt in $optforprofiles; do
+        for opt in $optforcolorschemes; do
             if [[ $opt = ${COMP_WORDS[1]} ]]; then
                 COMPREPLY=($(compgen -W "$(wpg -l)" -- "$cur"))
             fi

--- a/completions/bash/wpg
+++ b/completions/bash/wpg
@@ -8,13 +8,13 @@ function _wpg() {
     # themes, filenames
     optvariable="-i -o"
 	# filenames
-    optfordefault="-y -a -xa -ax"
+    optfordefault="--link -aL -La -a -ta -at"
 	# templates
-    optfortemplates="-xd -dx"
+    optfortemplates="-td -dt"
 	# pywal backends
 	optforbackends="--backends"
 	# pywal themes
-	optforthemes="--pywal"
+	optforthemes="--theme"
 
     if [[ $COMP_CWORD = 1 ]]; then
         COMPREPLY=($(compgen -W "$(_parse_usage wpg)" -- "$cur"))
@@ -31,7 +31,7 @@ function _wpg() {
         done
         for opt in $optforthemes; do
             if [[ $opt = ${COMP_WORDS[1]} ]]; then
-                COMPREPLY=($(compgen -W "$(wpg --pywal)" -- "$cur"))
+                COMPREPLY=($(compgen -W "$(wpg --theme)" -- "$cur"))
             fi
         done
         for opt in $optvariable; do
@@ -45,7 +45,7 @@ function _wpg() {
             if [[ $opt = ${COMP_WORDS[1]} && $COMP_CWORD < 3 ]]; then
                 COMPREPLY=($(compgen -W "$(wpg -l)" -- "$cur"))
             elif [[ $opt = ${COMP_WORDS[1]} ]]; then
-                COMPREPLY=($(compgen -W "$(wpg --pywal)" -- "$cur"))
+                COMPREPLY=($(compgen -W "$(wpg --theme)" -- "$cur"))
             fi
         done
         for opt in $optfordefault; do
@@ -55,7 +55,7 @@ function _wpg() {
         done
         for opt in $optfortemplates; do
             if [[ $opt = ${COMP_WORDS[1]} ]]; then
-                COMPREPLY=($(compgen -W "$(wpg -xl)" -- "$cur"))
+                COMPREPLY=($(compgen -W "$(wpg -tl)" -- "$cur"))
             fi
         done
     fi

--- a/completions/zsh/_wpg
+++ b/completions/zsh/_wpg
@@ -8,7 +8,7 @@ _profiles() {
 
 _templates() {
     local -a templates
-    templates=(`wpg -xl`)
+    templates=(`wpg -tl`)
     _describe 'templates' templates
 }
 
@@ -20,7 +20,7 @@ _backends() {
 
 _themes() {
     local -a themes
-    themes=(`wpg --pywal`)
+    themes=(`wpg --theme`)
     _describe 'themes' themes
 }
 
@@ -33,13 +33,13 @@ _wpg() {
     # themes, pywal themes
     optvariabletheme=(-Ti)
     # filenames
-    optforgeneric=(-y -a -xa)
+    optforgeneric=(--link -a -La -aL -ta -at --update_template)
     # templates
-    optfortemplates=(-xd -dx)
+    optfortemplates=(-td -dt)
     # pywal backends
     optforbackends=(--backend)
     # pywal themes
-    optforthemes=(--pywal)
+    optforthemes=(--theme)
 
     _arguments \
         '1: :->generic' \

--- a/completions/zsh/_wpg
+++ b/completions/zsh/_wpg
@@ -7,9 +7,9 @@ _profiles() {
 }
 
 _templates() {
-    local -a templates
-    templates=(`wpg -tl`)
-    _describe 'templates' templates
+	local -a templates
+	templates=(`wpg -tl`)
+	_describe 'templates' templates
 }
 
 _backends() {
@@ -27,7 +27,7 @@ _themes() {
 _wpg() {
     local state optforprofiles
     # themes
-    optforprofiles=(-s -e -d -z -m -A -LA --brt --sat) 
+    optforprofiles=(-s -e -d -z -m -A -LA --brt --sat -R)
     # themes, filenames
     optvariable=(-i -o)
     # themes, pywal themes
@@ -90,9 +90,9 @@ _wpg() {
                         _themes
                     fi
                 done
-            fi 
-            ;;
-    esac
+			fi 
+			;;
+	esac
 }
 
 _wpg "$@"

--- a/completions/zsh/_wpg
+++ b/completions/zsh/_wpg
@@ -1,9 +1,9 @@
 #compdef wpg
 
-_profiles() {
-    local -a profiles
-    profiles=(`wpg -l`)
-    _describe 'profiles' profiles
+_colorschemes() {
+    local -a colorschemes
+    colorschemes=(`wpg -l`)
+    _describe 'colorschemes' colorschemes
 }
 
 _templates() {
@@ -25,15 +25,15 @@ _themes() {
 }
 
 _wpg() {
-    local state optforprofiles
+    local state optforcolorschemes
     # themes
-    optforprofiles=(-s -e -d -z -m -A -LA --brt --sat -R)
+    optforcolorschemes=(-s -e -d -z -m -A -LA --brt --sat -R)
     # themes, filenames
     optvariable=(-i -o)
     # themes, pywal themes
     optvariabletheme=(-Ti)
     # filenames
-    optforgeneric=(--link -a -La -aL -ta -at --update_template)
+    optforgeneric=(--link -a -La -aL -ta -at --update)
     # templates
     optfortemplates=(-td -dt)
     # pywal backends
@@ -43,29 +43,29 @@ _wpg() {
 
     _arguments \
         '1: :->generic' \
-        '*: :->listprofiles'
+        '*: :->listcolorschemes'
 
     case $state in
         (generic)
             _gnu_generic
             ;;
-        (listprofiles)
+        (listcolorschemes)
             if [[ $CURRENT < 5 || ${words[2]} != "-s" ]]; then
-                for opt in $optforprofiles; do
+                for opt in $optforcolorschemes; do
                     if [[ $opt = ${words[2]} ]]; then
-                        _profiles
+                        _colorschemes
                     fi
                 done
                 for opt in $optvariable; do
                     if [[ $opt = ${words[2]} && $CURRENT < 4 ]]; then
-                        _profiles
+                        _colorschemes
                     elif [[ $opt = ${words[2]} ]]; then
                         _gnu_generic
                     fi
                 done
                 for opt in $optvariabletheme; do
                     if [[ $opt = ${words[2]} && $CURRENT < 4 ]]; then
-                        _profiles
+                        _colorschemes
                     elif [[ $opt = ${words[2]} ]]; then
                         _themes
                     fi

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setuptools.setup(
     python_requires=">=3.5",
     install_requires=[
         'Pillow>=4.2.1',
-        'pywal>=2.0.0',
+        'pywal>=3.0.0',
     ],
     include_package_data=True,
     data_files=[('etc/wpgtk', ['wpgtk/misc/wpg.conf']),

--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -114,6 +114,14 @@ def read_args(args):
                         help="set a one time alpha value",
                         nargs=1)
 
+    parser.add_argument("--preview",
+                        help="preview your current colorscheme",
+                        action="store_true")
+
+    parser.add_argument("--update_template",
+                        help="update template(s) of your choice "
+                        "to the new format",
+                        nargs="+")
 
     return parser.parse_args()
 
@@ -146,10 +154,19 @@ def process_args(args):
     if args.alpha:
         settings["alpha"] = args.alpha[0]
 
-    if args.m:
-        filename = random.choice(files.get_file_list())
-        themer.set_theme(filename, filename, args.r)
+    if args.preview:
+        pywal.colors.palette()
         exit(0)
+
+    if args.m:
+        file_list = files.get_file_list()
+        if len(file_list) > 0:
+            filename = random.choice(file_list)
+            themer.set_theme(filename, filename, args.r)
+            exit(0)
+        else:
+            logging.error("you have no themes")
+            exit(1)
 
     if args.s:
         if len(args.s) == 1:
@@ -269,8 +286,10 @@ def main():
     try:
         _gui = __import__("wpgtk.gui.theme_picker", fromlist=['theme_picker'])
         _gui.run(args)
+        exit(0)
     except NameError:
         logging.error("missing pygobject module, use cli")
+        exit(1)
 
 
 if __name__ == "__main__":

--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -97,7 +97,7 @@ def read_args(args):
 
     parser.add_argument("--link",
                         help="link config file to template backup "
-                        "[config, .base]",
+                        "[.base, config]",
                         nargs=2)
 
     parser.add_argument("--sat",
@@ -229,7 +229,7 @@ def process_args(args):
         exit(0)
 
     if args.link:
-        files.add_template(args.link[0], args.link[1])
+        files.add_template(args.link[1], args.link[0])
         exit(0)
 
     if args.i:

--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -29,33 +29,41 @@ def read_args(args):
                         help="delete the wallpaper(s) from wallpaper folder",
                         nargs="+")
 
+    parser.add_argument("-t",
+                        help="add, remove and list templates instead "
+                        "of themes",
+                        action="store_true")
+
     parser.add_argument("-s",
                         help="set the wallpaper and/or colorscheme",
                         nargs="+")
 
-    parser.add_argument("-m",
-                        help="pick a random wallpaper/colorscheme",
-                        action="store_true")
-
     parser.add_argument('-l',
                         help="see which wallpapers are available",
-                        action="store_true")
-
-    parser.add_argument("-t",
-                        help="add, remove and list templates instead "
-                        "of themes",
                         action="store_true")
 
     parser.add_argument("-n",
                         help="avoid setting a wallpaper",
                         action="store_true")
 
-    parser.add_argument("-r",
-                        help="restore the wallpaper and colorscheme",
+    parser.add_argument("-m",
+                        help="pick a random wallpaper/colorscheme",
                         action="store_true")
 
     parser.add_argument("-c",
                         help="shows the current wallpaper",
+                        action="store_true")
+
+    parser.add_argument("-z",
+                        help="shuffles the given colorscheme(s)",
+                        nargs="+")
+
+    parser.add_argument("-A",
+                        help="auto-adjusts the given colorscheme(s)",
+                        nargs="+")
+    
+    parser.add_argument("-r",
+                        help="restore the wallpaper and colorscheme",
                         action="store_true")
 
     parser.add_argument("-L", "--light",
@@ -72,14 +80,6 @@ def read_args(args):
                         help="assign a pywal theme to specific wallpaper"
                         " instead of a json file",
                         action="store_true")
-
-    parser.add_argument("-z",
-                        help="shuffles the given colorscheme(s)",
-                        nargs="+")
-
-    parser.add_argument("-A",
-                        help="auto-adjusts the given colorscheme(s)",
-                        nargs="+")
 
     parser.add_argument("-i",
                         help="import a theme in json format and asign "

--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -122,7 +122,7 @@ def read_args(args):
                         help="preview your current colorscheme",
                         action="store_true")
 
-    parser.add_argument("--update_template",
+    parser.add_argument("--update",
                         help="update template(s) of your choice "
                         "to the new format",
                         nargs="+")
@@ -280,9 +280,9 @@ def process_args(args):
         print("\n".join(pywal.colors.list_backends()))
         exit(0)
 
-    if args.update_template:
-        for arg in args.update_template:
-            files.update_template(arg)
+    if args.update:
+        for arg in args.update:
+            files.update(arg)
         exit(0)
 
     if args.backend and args.backend != "list":

--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -18,6 +18,10 @@ from .data.config import settings
 def read_args(args):
     parser = argparse.ArgumentParser()
 
+    parser.add_argument("--version",
+                        help="print the current version",
+                        action="store_true")
+
     parser.add_argument("-a",
                         help="add a wallpaper and generate a colorscheme",
                         nargs="+")
@@ -38,16 +42,17 @@ def read_args(args):
                         help="see which wallpapers are available",
                         action="store_true")
 
+    parser.add_argument("-t",
+                        help="add, remove and list templates instead "
+                        "of themes",
+                        action="store_true")
+
     parser.add_argument("-n",
-                        help="don't change wallpaper",
+                        help="avoid setting a wallpaper",
                         action="store_true")
 
     parser.add_argument("-r",
                         help="restore the wallpaper and colorscheme",
-                        action="store_true")
-
-    parser.add_argument("--version",
-                        help="print the current version",
                         action="store_true")
 
     parser.add_argument("-c",
@@ -58,19 +63,15 @@ def read_args(args):
                         help="temporarily enable light themes",
                         action="store_true")
 
+    parser.add_argument("--theme",
+                        help="list included pywal themes "
+                        "or replace your current colorscheme with a "
+                        "selection of your own",
+                        const="list", nargs="?")
+
     parser.add_argument("-T",
                         help="assign a pywal theme to specific wallpaper"
                         " instead of a json file",
-                        action="store_true")
-
-    parser.add_argument("-t",
-                        help="send color sequences to all "
-                        "terminals (deprecated)",
-                        action="store_true")
-
-    parser.add_argument("-x",
-                        help="add, remove and list templates instead "
-                        "of themes",
                         action="store_true")
 
     parser.add_argument("-z",
@@ -113,11 +114,6 @@ def read_args(args):
                         help="set a one time alpha value",
                         nargs=1)
 
-    parser.add_argument("--pywal",
-                        help="list included pywal themes "
-                        "or replace your current colorscheme with a "
-                        "selection of your own",
-                        const="list", nargs="?")
 
     return parser.parse_args()
 
@@ -171,15 +167,11 @@ def process_args(args):
         exit(0)
 
     if args.l:
-        if args.x:
+        if args.t:
             templates = files.get_file_list(OPT_DIR, False)
             any(print(t) for t in templates if ".base" in t)
         else:
             print("\n".join(files.get_file_list()))
-        exit(0)
-
-    if args.t:
-        Popen(["cat", path.join(WPG_DIR, "sequences")])
         exit(0)
 
     if args.version:
@@ -187,13 +179,13 @@ def process_args(args):
         exit(0)
 
     if args.d:
-        delete_action = files.delete_template if args.x \
+        delete_action = files.delete_template if args.t \
                         else themer.delete_theme
         any(delete_action(x) for x in args.d)
         exit(0)
 
     if args.a:
-        add_action = files.add_template if args.x \
+        add_action = files.add_template if args.t \
                      else themer.create_theme
         for x in args.a:
             if path.isfile(glob.glob(x)[0]):
@@ -230,7 +222,7 @@ def process_args(args):
         themer.export_theme(*args.o)
         exit(0)
 
-    if args.pywal == "list":
+    if args.theme == "list":
         name_dic = pywal.theme.list_themes()
         name_list = [t.name.replace(".json", "") for t in name_dic]
         print("\n".join(name_list))
@@ -254,12 +246,17 @@ def process_args(args):
         sample.create_sample(cl, files.get_sample_path(args.brt[0]))
         exit(0)
 
-    if args.pywal and args.pywal != "list":
-        themer.set_pywal_theme(args.pywal)
+    if args.theme and args.theme != "list":
+        themer.set_pywal_theme(args.theme)
         exit(0)
 
     if args.backend == "list":
         print("\n".join(pywal.colors.list_backends()))
+        exit(0)
+
+    if args.update_template:
+        for arg in args.update_template:
+            files.update_template(arg)
         exit(0)
 
     if args.backend and args.backend != "list":

--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -282,7 +282,8 @@ def process_args(args):
 
     if args.update:
         for arg in args.update:
-            files.update(arg)
+            if arg.endswith(".base"):
+                files.update_template(arg)
         exit(0)
 
     if args.backend and args.backend != "list":

--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -85,15 +85,16 @@ def read_args(args):
                         help="import a theme in json format and asign "
                         "to wallpaper [wallpaper, json]",
                         nargs=2)
+
     parser.add_argument("-o",
                         help="export a theme in json "
                         "format [wallpaper, json]",
                         nargs="+")
 
-    parser.add_argument("-y",
-                        help="link config file to template backup"
-                        "[config, basefile]",
-                        nargs="+")
+    parser.add_argument("--link",
+                        help="link config file to template backup "
+                        "[config, .base]",
+                        nargs=2)
 
     parser.add_argument("--sat",
                         help="add or substract the saturation of a "
@@ -128,14 +129,6 @@ def process_arg_errors(args):
 
     if args.s and len(args.s) > 2:
         logging.error("specify at most 2 filenames")
-        exit(1)
-
-    if args.y and len(args.y) != 2:
-        logging.error("specify a config and a basefile")
-        exit(1)
-
-    if args.i and len(args.i) != 2:
-        logging.error("specify a wallpaper and a colorscheme json")
         exit(1)
 
     if args.o and len(args.o) != 2:
@@ -209,8 +202,8 @@ def process_args(args):
             logging.info("shuffled %s" % arg)
         exit(0)
 
-    if args.y:
-        files.add_template(args.y[0], args.y[1])
+    if args.link:
+        files.add_template(args.link[0], args.link[1])
         exit(0)
 
     if args.i:

--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -5,13 +5,12 @@ import logging
 import argparse
 import glob
 from os import path
-from subprocess import Popen
 from .data import files
 from .data import themer
 from .data import color
 from .data import util
 from .data import sample
-from .data.config import OPT_DIR, WPG_DIR, __version__
+from .data.config import OPT_DIR, __version__
 from .data.config import settings
 
 

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -33,6 +33,7 @@ def get_color_list(filename, json=False):
     """extract a list with 16 colors from a json or a pywal dict"""
     is_new = not os.path.isfile(files.get_cache_path(filename))
     auto_adjust = settings.getboolean("auto_adjust", True)
+    light_theme = settings.getboolean("light_theme", False)
 
     if json:
         theme = pywal.util.read_file_json(filename)
@@ -45,7 +46,7 @@ def get_color_list(filename, json=False):
         color_list = list(theme["colors"].values())
 
     if is_new and not json:
-        if auto_adjust:
+        if auto_adjust or light_theme:
             color_list = auto_adjust_colors(color_list)
         sample.create_sample(color_list, files.get_sample_path(filename))
         write_colors(filename, color_list)

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -213,7 +213,7 @@ def wpgtk_colors(hexc, is_dark_theme=True):
     brightness = util.get_hls_val(hexc, "light")
 
     active = util.alter_brightness(hexc, brightness * -0.20) \
-        if is_dark_theme else util.alter_brightness(hexc, brightness * -0.20)
+        if is_dark_theme else util.alter_brightness(hexc, brightness * 0.30)
 
     inactive = util.alter_brightness(hexc, brightness * -0.45) \
         if is_dark_theme else hexc

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -14,13 +14,16 @@ from . import util
 from . import sample
 
 
-def get_pywal_dict(wallpaper):
+def get_pywal_dict(wallpaper, is_file=False):
     """get the color dictionary of a given wallpaper"""
+    light_theme = settings.getboolean("light_theme", False)
     pywal.util.Color.alpha_num = settings.get("alpha", "100")
+
     image = pywal.image.get(os.path.join(WALL_DIR, wallpaper))
 
     return pywal.colors.get(
         image,
+        light=(is_file and light_theme),
         backend=settings.get("backend", "wal"),
         cache_dir=WPG_DIR
     )

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -2,6 +2,7 @@ import sys
 import logging
 import pywal
 import os
+import re
 from operator import itemgetter
 from subprocess import Popen
 from random import shuffle, randint

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -81,27 +81,21 @@ def change_colors(colors, which):
     if which in FILE_DIC:
         which = FILE_DIC[which]
 
-    tmp_filename = which + ".base"
     try:
-        with open(tmp_filename, "r") as tmp_file:
+        with open("%s.base" % which, "r") as tmp_file:
             first_line = tmp_file.readline()
-            tmp_file.seek(0)
-            tmp_data = tmp_file.read()
 
-        if "wpgtk-ignore" not in first_line:
-            for k, v in user_keywords.items():
-                tmp_data = tmp_data.replace(util.build_key(k), v)
+            if "wpgtk-ignore" not in first_line:
+                tmp_file.seek(0)
+                tmp_data = tmp_file.read()
+                tmp_data = tmp_data.format_map(colors)
 
-            for k, v in {**colors["wpgtk"], **colors["colors"]}.items():
-                tmp_data = tmp_data.replace(util.build_key(k.upper()), v.strip("#"))
+                with open(which, "w") as target_file:
+                    target_file.write(tmp_data)
+                    logging.info("wrote: %s" % opt.split("/").pop())
 
-            if colors["icons"] and opt == "icon-step1":
-                for k, v in colors["icons"].items():
-                    tmp_data = tmp_data.replace(k, v.strip("#"))
-
-            with open(which, "w") as target_file:
-                target_file.write(tmp_data)
-                logging.info("wrote: %s" % opt.split("/").pop())
+    except KeyError as e:
+        logging.error("%s in %s - key does not exist" % (e, opt))
 
     except IOError:
         logging.error("%s - base file does not exist" % opt)

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -3,6 +3,7 @@ import logging
 import pywal
 import os
 import re
+import threading
 from operator import itemgetter
 from subprocess import Popen
 from random import shuffle, randint
@@ -174,7 +175,9 @@ def change_templates(colors):
     try:
         for template in templates:
             original = template.split(".base").pop(0)
-            change_colors(colors, os.path.join(OPT_DIR, original))
+            args = (colors, os.path.join(OPT_DIR, original))
+            t = threading.Thread(target=change_colors, args=args)
+            t.start()
 
     except Exception as e:
         logging.error(str(e))

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -111,7 +111,7 @@ def smart_sort(colors):
     """automatically set the most look-alike colors to their
     corresponding place in the standar xterm colors"""
     colors = colors[:8]
-    sorted_by_color = []
+    sorted_by_color = list()
     base_colors = ["#000000", "#ff0000", "#00ff00", "#ffff00",
                    "#0000ff", "#ff00ff", "#00ffff", "#ffffff"]
 

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -32,6 +32,7 @@ def get_pywal_dict(wallpaper, is_file=False):
 def get_color_list(filename, json=False):
     """extract a list with 16 colors from a json or a pywal dict"""
     is_new = not os.path.isfile(files.get_cache_path(filename))
+    auto_adjust = settings.getboolean("auto_adjust", True)
 
     if json:
         theme = pywal.util.read_file_json(filename)
@@ -44,6 +45,8 @@ def get_color_list(filename, json=False):
         color_list = list(theme["colors"].values())
 
     if is_new and not json:
+        if auto_adjust:
+            color_list = auto_adjust_colors(color_list)
         sample.create_sample(color_list, files.get_sample_path(filename))
         write_colors(filename, color_list)
 
@@ -152,7 +155,7 @@ def auto_adjust_colors(clist):
     if light == is_dark_theme(clist):
         clist[7], clist[0] = clist[0], clist[7]
 
-    comment = [alter_brightness(clist[0], sign * 20)]
+    comment = [alter_brightness(clist[0], sign * 25)]
     fg = [alter_brightness(clist[7], sign * 60)]
     clist = clist[:8] + comment \
         + [alter_brightness(x, sign * get_hls_val(x, "light") * 0.3, added_sat)

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -163,33 +163,6 @@ def auto_adjust_colors(clist):
     return clist
 
 
-def add_icon_colors(colors):
-    try:
-        glyph = util.alter_brightness(colors["wpgtk"]["COLORIN"], -15)
-        icon_dic = {}
-
-        with open(FILE_DIC["icon-step1"], "r") as icon_file:
-            for line in icon_file:
-                if("glyphColorNew=" in line):
-                    icon_dic["oldglyph"] = line.split("=")[1].strip("\n")
-
-                if("frontColorNew=" in line):
-                    icon_dic["oldfront"] = line.split("=")[1].strip("\n")
-
-                if("backColorNew=" in line):
-                    icon_dic["oldback"] = line.split("=")[1].strip("\n")
-
-        icon_dic["newglyph"] = glyph
-        icon_dic["newfront"] = colors["wpgtk"]["COLORACT"]
-        icon_dic["newback"] = colors["wpgtk"]["COLORIN"]
-
-        return icon_dic
-
-    except IOError:
-        logging.error("icons - base file does not exists")
-        return
-
-
 def change_templates(colors):
     """call change_colors on each custom template
     installed or defined by the user"""

--- a/wpgtk/data/config.py
+++ b/wpgtk/data/config.py
@@ -3,7 +3,7 @@ import shutil
 import os
 import logging
 
-__version__ = '5.8.7'
+__version__ = '6.0.0'
 
 parser = None
 

--- a/wpgtk/data/files.py
+++ b/wpgtk/data/files.py
@@ -54,7 +54,7 @@ def get_cache_path(wallpaper, backend=None):
 def get_sample_path(wallpaper, backend=None):
     """gets a wallpaper colorscheme sample's path"""
     if not backend:
-        backend = settings.get('backend', 'wal')
+        backend = settings.get("backend", "wal")
 
     sample_filename = "%s_%s_sample.png" % (wallpaper, backend)
 
@@ -109,6 +109,27 @@ def delete_colorschemes(wallpaper):
             os.remove(get_sample_path(wallpaper, backend))
         except OSError:
             pass
+
+
+def update_color(matchobj):
+    if matchobj.group(1):
+        return "{%s}" % matchobj.group(1).lower()
+
+
+def update_template(template_path):
+    with open(template_path, "r") as f:
+        tmp_data = f.read()
+
+        logging.info("escaping legitimate curly braces {} -> {{}}")
+        tmp_data = tmp_data.replace("{", "{{")
+        tmp_data = tmp_data.replace("}", "}}")
+
+        logging.info("replacing #<COLORXX> with braces {colorxx}")
+        tmp_data = re.sub(r"#<(COLOR[0-9]{1,2})>", update_color, tmp_data)
+        tmp_data = tmp_data.replace("#<COLORACT>", "{active}")
+        tmp_data = tmp_data.replace("#<COLORIN>", "{inactive}")
+
+        logging.info("%s update complete" % template_path)
 
 
 def change_current(filename):

--- a/wpgtk/data/files.py
+++ b/wpgtk/data/files.py
@@ -117,6 +117,8 @@ def update_color(matchobj):
 
 
 def update_template(template_path):
+    tmp_data = ""
+
     with open(template_path, "r") as f:
         tmp_data = f.read()
 
@@ -129,6 +131,9 @@ def update_template(template_path):
         tmp_data = tmp_data.replace("#<COLORACT>", "{active}")
         tmp_data = tmp_data.replace("#<COLORIN>", "{inactive}")
 
+    with open(template_path, "w") as f:
+        logging.info("writting %s" % template_path)
+        f.write(tmp_data)
         logging.info("%s update complete" % template_path)
 
 

--- a/wpgtk/data/files.py
+++ b/wpgtk/data/files.py
@@ -26,10 +26,24 @@ def get_file_list(path=WALL_DIR, images=True):
         return files
 
 
+def write_script(wallpaper, colorscheme):
+    """writes the script that should be called on startup
+    to restore the theme."""
+    set_wall = settings.getboolean("set_wallpaper", True)
+    light_theme = settings.getboolean("light_theme", True)
+
+    flags = "-rs" if set_wall else "-nrs"
+    flags += "L" if light_theme else ""
+
+    with open(join(WPG_DIR, "wp_init.sh"), "w") as script:
+        command = "wpg %s '%s' '%s'" % (flags, wallpaper, colorscheme)
+        script.writelines(["#!/usr/bin/env bash\n", command])
+
+
 def get_cache_path(wallpaper, backend=None):
     """get a colorscheme cache path using a wallpaper name"""
     if not backend:
-        backend = settings.get('backend', 'wal')
+        backend = settings.get("backend", "wal")
 
     filepath = join(WALL_DIR, wallpaper)
     filename = cache_fname(filepath, backend, False, WPG_DIR)

--- a/wpgtk/data/reload.py
+++ b/wpgtk/data/reload.py
@@ -60,4 +60,5 @@ def all():
     reload.i3()
     reload.polybar()
     reload.gtk()
+    reload.kitty()
     reload.sway()

--- a/wpgtk/data/reload.py
+++ b/wpgtk/data/reload.py
@@ -6,7 +6,7 @@ import tempfile
 from pywal import reload
 
 from . import util
-from .config import FORMAT_DIR, HOME
+from .config import FORMAT_DIR, HOME, settings
 
 
 def xrdb():
@@ -36,7 +36,7 @@ def openbox():
 
 
 def gtk3():
-    if shutil.which("xsettingsd"):
+    if shutil.which("xsettingsd") and settings.getboolean("gtk", True):
         fd, path = tempfile.mkstemp()
         try:
             with os.fdopen(fd, 'w+') as tmp:
@@ -56,9 +56,11 @@ def all():
     tint2()
     dunst()
     openbox()
-    gtk3()
     reload.i3()
     reload.polybar()
     reload.gtk()
     reload.kitty()
     reload.sway()
+
+    if settings.getboolean("gtk", True):
+        gtk3()

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -44,16 +44,11 @@ def set_theme(wallpaper, colorscheme, restore=False):
         set_wall = filepath if path.isfile(filepath) else colors["wallpaper"]
         pywal.wallpaper.change(set_wall)
 
-    flags = "-rs" if set_wall else "-nrs"
-    with open(path.join(WPG_DIR, "wp_init.sh"), "w") as script:
-        script.writelines(["#!/usr/bin/env bash\n",
-                           "wpg %s '%s' '%s'" %
-                           (flags, wallpaper, colorscheme)])
+    files.write_script(wallpaper, colorscheme)
+    files.change_current(wallpaper)
 
     Popen(['chmod', '+x', path.join(WPG_DIR, "wp_init.sh")])
     reload.xrdb()
-
-    files.change_current(wallpaper)
 
     if settings.getboolean('execute_cmd'):
         Popen(['bash', '-c', settings['command']])

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -58,12 +58,8 @@ def set_theme(wallpaper, colorscheme, restore=False):
 
 
 def delete_theme(filename):
-    try:
-        remove(path.join(WALL_DIR, filename))
-        files.delete_colorschemes(filename)
-    except IOError as e:
-        logging.error("file not available")
-        logging.error(e.message)
+    remove(path.join(WALL_DIR, filename))
+    files.delete_colorschemes(filename)
 
 
 def get_current():

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -30,8 +30,11 @@ def create_theme(filepath):
 
 def set_theme(wallpaper, colorscheme, restore=False):
     """apply a given wallpaper and a given colorscheme"""
+    is_file = path.isdir(colorscheme) or path.isfile(colorscheme)
+    target = colorscheme if is_file else path.join(WALL_DIR, colorscheme)
+
     set_wall = settings.getboolean("set_wallpaper", True)
-    colors = color.get_pywal_dict(path.join(WALL_DIR, colorscheme))
+    colors = color.get_pywal_dict(target, is_file)
     pywal.sequences.send(colors, WPG_DIR)
 
     if not restore:

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -67,6 +67,14 @@ def get_current():
     return image
 
 
+def reset_theme(theme_name):
+    """restore a colorscheme to it's original state by deleting
+    and re adding the image"""
+    wallpaper = realpath(path.join(WALL_DIR, theme_name))
+    delete_theme(theme_name)
+    create_theme(wallpaper)
+
+
 def import_theme(wallpaper, json_file, theme=False):
     """import a colorscheme from a JSON file either in
     terminal.sexy or pywal format"""

--- a/wpgtk/data/util.py
+++ b/wpgtk/data/util.py
@@ -67,10 +67,6 @@ def setup_log():
     logging.addLevelName(logging.WARNING, "w")
 
 
-def build_key(keyword):
-    return "<{}>".format(keyword)
-
-
 def get_pid(name):
     """Check if a process is running, borrowed from a newer pywal version"""
     try:

--- a/wpgtk/data/util.py
+++ b/wpgtk/data/util.py
@@ -62,9 +62,9 @@ def setup_log():
                                " %(module)-13s %(message)s",
                         level=logging.INFO,
                         stream=sys.stdout)
-    logging.addLevelName(logging.ERROR, "err")
-    logging.addLevelName(logging.INFO, "inf")
-    logging.addLevelName(logging.WARNING, "wrn")
+    logging.addLevelName(logging.ERROR, "e")
+    logging.addLevelName(logging.INFO, "i")
+    logging.addLevelName(logging.WARNING, "w")
 
 
 def build_key(keyword):

--- a/wpgtk/gui/color_grid.py
+++ b/wpgtk/gui/color_grid.py
@@ -7,6 +7,7 @@ from ..data import color
 from ..data import util
 from ..data import files
 from ..data import sample
+from ..data import themer
 
 from .color_picker import ColorDialog
 from gi import require_version
@@ -267,15 +268,19 @@ class ColorGrid(Gtk.Grid):
         current_walls = files.get_file_list()
         self.selected_file = current_walls[x]
         sample_path = files.get_sample_path(self.selected_file)
-        self.color_list = color.get_color_list(self.selected_file)
+        try:
+            self.color_list = color.get_color_list(self.selected_file)
+        except SystemExit:
+            self.color_list = themer.set_fallback_theme(self.selected_file)
         self.render_buttons()
 
         try:
             self.pixbuf_sample = GdkPixbuf.Pixbuf\
                 .new_from_file_at_size(sample_path, width=500, height=300)
-            self.sample.set_from_pixbuf(self.pixbuf_sample)
         except:
             sample.create_sample(self.color_list, sample_path)
+            self.pixbuf_sample = GdkPixbuf.Pixbuf\
+                .new_from_file_at_size(sample_path, width=500, height=300)
 
-        # Refresh parent's sample pixbuf
+        self.sample.set_from_pixbuf(self.pixbuf_sample)
         self.parent.sample.set_from_pixbuf(self.pixbuf_sample)

--- a/wpgtk/gui/color_grid.py
+++ b/wpgtk/gui/color_grid.py
@@ -64,6 +64,11 @@ class ColorGrid(Gtk.Grid):
         self.button_grid.set_column_spacing(PAD)
         self.button_grid.set_row_spacing(PAD)
 
+        self.combo_grid = Gtk.Grid()
+        self.combo_grid.set_column_homogeneous(1)
+        self.combo_grid.set_column_spacing(PAD)
+        self.combo_grid.set_row_spacing(PAD)
+
         self.color_list = ['000000']*16
         self.button_list = [Gtk.Button('000000') for x in range(16)]
         self.selected_file = ""
@@ -104,6 +109,10 @@ class ColorGrid(Gtk.Grid):
         self.auto_button.connect("pressed", self.on_auto_click)
         self.auto_button.set_sensitive(False)
 
+        self.reset_button = Gtk.Button("Reset")
+        self.reset_button.set_sensitive(False)
+        self.reset_button.connect("pressed", self.on_reset_click)
+
         self.done_lbl = Gtk.Label("")
 
         option_list = Gtk.ListStore(str)
@@ -116,10 +125,13 @@ class ColorGrid(Gtk.Grid):
         self.option_combo.set_entry_text_column(0)
         self.option_combo.connect("changed", self.combo_box_change)
 
-        self.button_grid.attach(self.import_button, 0, 0, 3, 1)
-        self.button_grid.attach(self.ok_button, 0, 1, 1, 1)
-        self.button_grid.attach(self.auto_button, 1, 1, 1, 1)
-        self.button_grid.attach(self.shuffle_button, 2, 1, 1, 1)
+        self.combo_grid.attach(self.option_combo, 0, 0, 3, 1)
+        self.combo_grid.attach(self.reset_button, 3, 0, 1, 1)
+
+        self.button_grid.attach(self.ok_button, 0, 0, 1, 1)
+        self.button_grid.attach(self.auto_button, 1, 0, 1, 1)
+        self.button_grid.attach(self.shuffle_button, 2, 0, 1, 1)
+        self.button_grid.attach(self.import_button, 3, 0, 1, 1)
 
         self.sat_light_grid.attach(self.sat_lbl, 0, 0, 1, 1)
         self.sat_light_grid.attach(self.sat_red, 1, 0, 1, 1)
@@ -129,7 +141,7 @@ class ColorGrid(Gtk.Grid):
         self.sat_light_grid.attach(self.light_red, 4, 0, 1, 1)
         self.sat_light_grid.attach(self.light_add, 5, 0, 1, 1)
 
-        self.attach(self.option_combo, 0, 0, 1, 1)
+        self.attach(self.combo_grid, 0, 0, 1, 1)
         self.attach(self.button_grid, 0, 1, 1, 1)
         self.attach(self.colorgrid, 0, 2, 1, 1)
         self.attach(self.sample, 0, 3, 1, 1)

--- a/wpgtk/gui/color_grid.py
+++ b/wpgtk/gui/color_grid.py
@@ -148,6 +148,26 @@ class ColorGrid(Gtk.Grid):
             button.modify_bg(Gtk.StateType.NORMAL, gcolor)
             button.modify_fg(Gtk.StateType.NORMAL, fgcolor)
 
+    def render_theme(self):
+        sample_path = files.get_sample_path(self.selected_file)
+
+        try:
+            self.color_list = color.get_color_list(self.selected_file)
+        except SystemExit:
+            self.color_list = themer.set_fallback_theme(self.selected_file)
+        self.render_buttons()
+
+        try:
+            self.pixbuf_sample = GdkPixbuf.Pixbuf\
+                .new_from_file_at_size(sample_path, width=500, height=300)
+        except:
+            sample.create_sample(self.color_list, sample_path)
+            self.pixbuf_sample = GdkPixbuf.Pixbuf\
+                .new_from_file_at_size(sample_path, width=500, height=300)
+
+        self.sample.set_from_pixbuf(self.pixbuf_sample)
+        self.parent.sample.set_from_pixbuf(self.pixbuf_sample)
+
     def hls_change(self, widget, *gparam):
         if gparam[0] == "sat":
             val = 0.05 if gparam[1] == "add" else -0.05
@@ -264,25 +284,10 @@ class ColorGrid(Gtk.Grid):
         self.import_button.set_sensitive(True)
         self.light_add.set_sensitive(True)
         self.light_red.set_sensitive(True)
+        self.reset_button.set_sensitive(True)
         self.sat_add.set_sensitive(True)
         self.sat_red.set_sensitive(True)
 
         current_walls = files.get_file_list()
         self.selected_file = current_walls[x]
-        sample_path = files.get_sample_path(self.selected_file)
-        try:
-            self.color_list = color.get_color_list(self.selected_file)
-        except SystemExit:
-            self.color_list = themer.set_fallback_theme(self.selected_file)
-        self.render_buttons()
-
-        try:
-            self.pixbuf_sample = GdkPixbuf.Pixbuf\
-                .new_from_file_at_size(sample_path, width=500, height=300)
-        except:
-            sample.create_sample(self.color_list, sample_path)
-            self.pixbuf_sample = GdkPixbuf.Pixbuf\
-                .new_from_file_at_size(sample_path, width=500, height=300)
-
-        self.sample.set_from_pixbuf(self.pixbuf_sample)
-        self.parent.sample.set_from_pixbuf(self.pixbuf_sample)
+        self.render_theme()

--- a/wpgtk/gui/color_grid.py
+++ b/wpgtk/gui/color_grid.py
@@ -158,10 +158,10 @@ class ColorGrid(Gtk.Grid):
             self.color_list = [util.alter_brightness(x, val, 0)
                                for x in self.color_list]
         self.render_buttons()
-        sample.create_sample(self.color_list)
         self.render_sample()
 
     def render_sample(self):
+        sample.create_sample(self.color_list)
         sample_path = os.path.join(WALL_DIR, ".tmp.sample.png")
         self.pixbuf_sample = GdkPixbuf.Pixbuf.new_from_file_at_size(
                 str(sample_path),
@@ -195,8 +195,11 @@ class ColorGrid(Gtk.Grid):
     def on_auto_click(self, widget):
         self.color_list = color.auto_adjust_colors(self.color_list)
         self.render_buttons()
-        sample.create_sample(self.color_list)
         self.render_sample()
+
+    def on_reset_click(self, widget):
+        themer.reset_theme(self.selected_file)
+        self.render_theme()
 
     def on_import_click(self, widget):
         fcd = Gtk.FileChooserDialog(
@@ -214,14 +217,12 @@ class ColorGrid(Gtk.Grid):
         if response == Gtk.ResponseType.OK:
             self.color_list = color.get_color_list(fcd.get_filename(), True)
             self.render_buttons()
-            sample.create_sample(self.color_list[:])
             self.render_sample()
         fcd.destroy()
 
     def on_shuffle_click(self, widget):
         self.color_list = color.shuffle_colors(self.color_list)
         self.render_buttons()
-        sample.create_sample(self.color_list)
         self.render_sample()
 
     def on_color_click(self, widget):
@@ -241,14 +242,15 @@ class ColorGrid(Gtk.Grid):
             if util.get_hls_val(hex_color, 'light') < 100:
                 fgcolor = Gdk.color_parse('#FFFFFF')
             else:
-                fgcolor = Gdk.color_parse('#101010')
+                fgcolor = Gdk.color_parse('#000000')
+
             widget.set_sensitive(True)
             widget.modify_bg(Gtk.StateType.NORMAL, gcolor)
             widget.modify_fg(Gtk.StateType.NORMAL, fgcolor)
+
             for i, c in enumerate(self.button_list):
                 if c.get_label() != self.color_list[i]:
                     self.color_list[i] = c.get_label()
-            sample.create_sample(self.color_list)
             self.render_sample()
         dialog.destroy()
 

--- a/wpgtk/gui/option_grid.py
+++ b/wpgtk/gui/option_grid.py
@@ -71,25 +71,35 @@ class OptionsGrid(Gtk.Grid):
         self.lbl_gtk = Gtk.Label("Reload GTK+")
 
         self.light_theme_switch = Gtk.Switch()
-        self.light_theme_switch.connect("notify::active",
-                                        self.on_activate, "light_theme")
+        self.light_theme_switch.connect(
+            "notify::active",
+            self.on_activate,
+            "light_theme"
+        )
         self.lbl_light_theme = Gtk.Label("Use Light Theme")
 
         self.wallpaper_switch = Gtk.Switch()
-        self.wallpaper_switch.connect("notify::active",
-                                      self.on_activate,
-                                      "set_wallpaper")
+        self.wallpaper_switch.connect(
+            "notify::active",
+            self.on_activate,
+            "set_wallpaper"
+        )
         self.lbl_wallpaper = Gtk.Label("Set wallpaper")
 
         self.smart_sort_switch = Gtk.Switch()
-        self.smart_sort_switch.connect("notify::active",
-                                       self.on_activate,
-                                       "smart_sort")
+        self.smart_sort_switch.connect(
+            "notify::active",
+            self.on_activate,
+            "smart_sort"
+        )
         self.lbl_smart_sort = Gtk.Label("Use smart sort")
 
         self.auto_adjust_switch = Gtk.Switch()
-        self.auto_adjust_switch.connect("notify::active",
-                                        self.on_activate, "auto_adjust")
+        self.auto_adjust_switch.connect(
+            "notify::active",
+            self.on_activate,
+            "auto_adjust"
+        )
         self.lbl_auto_adjust = Gtk.Label("Always auto adjust")
 
         # edit cmd
@@ -100,11 +110,16 @@ class OptionsGrid(Gtk.Grid):
         # cmd
         self.command_lbl = Gtk.Label("Run command after Colorize")
         self.command_exe_lbl = Gtk.Label("Command: ")
+
         self.command_txt = Gtk.Entry()
         self.command_txt.connect("changed", self.on_txt_change, "command")
+
         self.command_switch = Gtk.Switch()
-        self.command_switch.connect("notify::active",
-                                    self.on_activate, "execute_cmd")
+        self.command_switch.connect(
+            "notify::active",
+            self.on_activate,
+            "execute_cmd"
+        )
 
         self.alpha_lbl = Gtk.Label('Alpha:')
         self.alpha_txt = Gtk.Entry()

--- a/wpgtk/gui/option_grid.py
+++ b/wpgtk/gui/option_grid.py
@@ -87,6 +87,11 @@ class OptionsGrid(Gtk.Grid):
                                        "smart_sort")
         self.lbl_smart_sort = Gtk.Label("Use smart sort")
 
+        self.auto_adjust_switch = Gtk.Switch()
+        self.auto_adjust_switch.connect("notify::active",
+                                        self.on_activate, "auto_adjust")
+        self.lbl_auto_adjust = Gtk.Label("Always auto adjust")
+
         # edit cmd
         self.editor_lbl = Gtk.Label("Open optional files with:")
         self.editor_txt = Gtk.Entry()
@@ -113,6 +118,9 @@ class OptionsGrid(Gtk.Grid):
         self.switch_grid.attach(self.lbl_gtk, 5, 1, 3, 1)
         self.switch_grid.attach(self.gtk_switch, 9, 1, 1, 1)
 
+        self.switch_grid.attach(self.lbl_auto_adjust, 5, 2, 3, 1)
+        self.switch_grid.attach(self.auto_adjust_switch, 9, 2, 1, 1)
+
         self.switch_grid.attach(self.command_lbl, 1, 2, 3, 1)
         self.switch_grid.attach(self.command_switch, 4, 2, 1, 1)
 
@@ -121,8 +129,6 @@ class OptionsGrid(Gtk.Grid):
 
         self.switch_grid.attach(self.lbl_smart_sort, 1, 4, 3, 1)
         self.switch_grid.attach(self.smart_sort_switch, 4, 4, 1, 1)
-
-        # cmd Grid attach
 
         # Active Grid attach
         self.active_grid.attach(self.backend_lbl, 1, 1, 1, 1)
@@ -168,6 +174,8 @@ class OptionsGrid(Gtk.Grid):
             .set_active(settings.getboolean("set_wallpaper", True))
         self.smart_sort_switch\
             .set_active(settings.getboolean("smart_sort", True))
+        self.auto_adjust_switch\
+            .set_active(settings.getboolean("auto_adjust", False))
 
         self.editor_txt\
             .set_text(settings.get("editor", "urxvt -e vim"))

--- a/wpgtk/gui/option_grid.py
+++ b/wpgtk/gui/option_grid.py
@@ -54,9 +54,11 @@ class OptionsGrid(Gtk.Grid):
         # Backend Combo
         self.backend_list = colors.list_backends()
         self.backend_lbl = Gtk.Label("Select your backend:")
+
         be_store = Gtk.ListStore(str)
         for elem in self.backend_list:
             be_store.append([elem])
+
         self.backend_combo = Gtk.ComboBox.new_with_model(be_store)
         self.backend_combo.pack_start(self.renderer_text, True)
         self.backend_combo.add_attribute(self.renderer_text, 'text', 0)
@@ -64,18 +66,9 @@ class OptionsGrid(Gtk.Grid):
         self.backend_combo.connect("changed", self.combo_box_change, "backend")
 
         # Switches
-        self.tint2_switch = Gtk.Switch()
-        self.tint2_switch.connect("notify::active",  self.on_activate, "tint2")
-        self.lbl_tint2 = Gtk.Label("Reload Tint2")
-
         self.gtk_switch = Gtk.Switch()
         self.gtk_switch.connect("notify::active",  self.on_activate, "gtk")
-        self.lbl_gtk = Gtk.Label("Reload GTK2")
-
-        self.openbox_switch = Gtk.Switch()
-        self.openbox_switch.connect("notify::active",
-                                    self.on_activate, "openbox")
-        self.lbl_openbox = Gtk.Label("Reload openbox")
+        self.lbl_gtk = Gtk.Label("Reload GTK+")
 
         self.light_theme_switch = Gtk.Switch()
         self.light_theme_switch.connect("notify::active",
@@ -123,14 +116,8 @@ class OptionsGrid(Gtk.Grid):
         self.switch_grid.attach(self.command_lbl, 1, 2, 3, 1)
         self.switch_grid.attach(self.command_switch, 4, 2, 1, 1)
 
-        self.switch_grid.attach(self.lbl_openbox, 5, 2, 3, 1)
-        self.switch_grid.attach(self.openbox_switch, 9, 2, 1, 1)
-
         self.switch_grid.attach(self.lbl_light_theme, 1, 3, 3, 1)
         self.switch_grid.attach(self.light_theme_switch, 4, 3, 1, 1)
-
-        self.switch_grid.attach(self.lbl_tint2, 5, 3, 3, 1)
-        self.switch_grid.attach(self.tint2_switch, 9, 3, 1, 1)
 
         self.switch_grid.attach(self.lbl_smart_sort, 1, 4, 3, 1)
         self.switch_grid.attach(self.smart_sort_switch, 4, 4, 1, 1)
@@ -173,12 +160,8 @@ class OptionsGrid(Gtk.Grid):
             .set_active(settings.getint("active", 0))
         self.gtk_switch\
             .set_active(settings.getboolean("gtk", True))
-        self.tint2_switch\
-            .set_active(settings.getboolean("tint2", True))
         self.command_switch\
             .set_active(settings.getboolean("execute_cmd", False))
-        self.openbox_switch\
-            .set_active(settings.getboolean("openbox", True))
         self.light_theme_switch\
             .set_active(settings.getboolean("light_theme", False))
         self.wallpaper_switch\

--- a/wpgtk/misc/wpg-install.sh
+++ b/wpgtk/misc/wpg-install.sh
@@ -141,6 +141,7 @@ install_icons()
 {
   echo "Installing icon pack";
   cp -r flattrcolor "${HOME}/.icons/" && \
+  cp -r flattrcolor-dark "${HOME}/.icons/" && \
     echo ":: flattr icons install done."
 }
 

--- a/wpgtk/misc/wpg.conf
+++ b/wpgtk/misc/wpg.conf
@@ -9,5 +9,6 @@ command = urxvt -e echo hi
 backend = wal
 alpha = 100
 auto_sort = true
+auto_adjust = false
 
 [keywords]

--- a/wpgtk/misc/wpg.conf
+++ b/wpgtk/misc/wpg.conf
@@ -1,9 +1,7 @@
 [settings]
 set_wallpaper = true
-openbox = true
 gtk = true
 active = 0
-tint2 = true
 light_theme = false
 editor = urxvt -e vim
 execute_cmd = false

--- a/wpgtk/misc/wpg.conf
+++ b/wpgtk/misc/wpg.conf
@@ -8,7 +8,7 @@ execute_cmd = false
 command = urxvt -e echo hi
 backend = wal
 alpha = 100
-auto_sort = true
+smart_sort = true
 auto_adjust = false
 
 [keywords]


### PR DESCRIPTION
I will be changing up a few things around, there are some breaking changes, so I think this is indeed worthy of a major version release, here's a checklist of things that I'm working on:

- [x] use pywal's template format (python's format strings)
- [x] leverage pywal's Color class and conversions
- [x] integrate a upgrade option in `wpgtk` to help users with custom templates migration
- [x] update user defined keywords so they work with the new format
- [x] port all templates to new format to install under `wpg-install.sh`
- [x] remove as much duplicated code as I can
- [x] add option to auto-adjust on theme generation
- [x] order command line arguments in a more logical manner
- [x] remove old options that are no longer relevant (openbox, tint2) they will reload as long as they're actively running
- [x] add dark variant for flattrcolor
- [x] update documentation
- [x] do a small video on new template format
- [x] allow the reset of a theme using GUI and CLI

## Now for the fun part (breaking changes)

Basically, the breaking changes come from the fact that the template format will change, I provide an example below:

```
#<COLOR8> becomes {color8}
#<COLORACT> becomes {active}
#<COLORIN> becomes {inactive}

if you have normal braces {{
   you will need to escape them like this
}}

but this means you can do things like: 
{color8}                -> #ffffff
{color8.octal}          -> #77777777
{active.rgb}            -> 255, 255, 255
{userdefinedcolor.rgb}  -> 0, 0, 0
#BA{color8.strip}       -> #BAffffff
```