### PR TITLE
Added reload.xrdb() back

### DIFF
--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -49,6 +49,8 @@ def set_theme(wallpaper, colorscheme, restore=False):
 
     files.write_script(wallpaper, colorscheme)
     files.change_current(wallpaper)
+    
+    reload.xrdb()
 
     Popen(['chmod', '+x', path.join(WPG_DIR, "wp_init.sh")])
 

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -41,6 +41,8 @@ def set_theme(wallpaper, colorscheme, restore=False):
         pywal.export.every(colors, FORMAT_DIR)
         color.apply_colorscheme(colors)
         reload.all()
+    else:
+        reload.xrdb()
 
     if set_wall:
         filepath = path.join(WALL_DIR, wallpaper)
@@ -50,8 +52,6 @@ def set_theme(wallpaper, colorscheme, restore=False):
     files.write_script(wallpaper, colorscheme)
     files.change_current(wallpaper)
     
-    reload.xrdb()
-
     Popen(['chmod', '+x', path.join(WPG_DIR, "wp_init.sh")])
 
     if settings.getboolean('execute_cmd'):


### PR DESCRIPTION
In the original commit, reload.xrdb() was supposed to be moved to be run before anything else. I'm not sure where it was supposed to be moved, but it got removed entirely, breaking wp_init.sh. I have added it back and now my terminal colors save upon reboot.  