### PR TITLE
Minor grammar edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 <img align="left" src="https://i.imgur.com/ApSuntN.gif" width="450px"/>
 
-`wpgtk` uses [pywal](https://github.com/dylanaraps/pywal) as it's colorscheme generator, but builds upon it with a graphic user interface and other features such as the abilty to edit the color-schemes generated and save them with their respective wallpapers, having light and dark themes for dynamic icons, hackable and fast GTK+ theme made specifically for `wpgtk`, custom keywords and values to replace in templates and auto color-scheme sorting to achieve more readable palletes.
+`wpgtk` uses [pywal](https://github.com/dylanaraps/pywal) as its colorscheme generator, but builds upon it with a graphic user interface and other features such as the abilty to edit the color-schemes generated and save them with their respective wallpapers, having light and dark themes for dynamic icons, hackable and fast GTK+ theme made specifically for `wpgtk`, custom keywords and values to replace in templates and auto color-scheme sorting to achieve more readable palletes.
 
-In short, `wpgtk` is a color-scheme manager with a template system which let's you create templates from any textfile and will replace keywords on it when you change your theme, delivering high customizing power.
+In short, `wpgtk` is a color-scheme manager with a template system which lets you create templates from any textfile and will replace keywords on it when you change your theme, delivering high customizing power.
 
 And also, for those who are not into auto-generated color-schemes, you will be happy to know that `wpgtk` includes all the preset themes that `pywal` does, so that's around 200+ themes to play around with, that you can also _modify_ to get really readable and cool results!
 


### PR DESCRIPTION
Possessive of "it" is written as "its" and not "it's" (http://its-not-its.info/)
Third person usage of "let" is written as "lets". "Let's" is short for "let us".

Also thank you for this amazing program. Just what I was looking for, for the last few months.