### PR TITLE
added option to disable calling themer.py's reload.all()

### DIFF
--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -61,7 +61,7 @@ def read_args(args):
     parser.add_argument("-A",
                         help="auto-adjusts the given colorscheme(s)",
                         nargs="+")
-    
+
     parser.add_argument("-r",
                         help="restore the wallpaper and colorscheme",
                         action="store_true")
@@ -126,6 +126,10 @@ def read_args(args):
                         help="update template(s) of your choice "
                         "to the new format",
                         nargs="+")
+
+    parser.add_argument("--noreload",
+                        help="do not reload",
+                        action="store_true")
 
     return parser.parse_args()
 
@@ -293,6 +297,9 @@ def process_args(args):
             if arg.endswith(".base"):
                 files.update_template(arg)
         exit(0)
+
+    if args.noreload:
+        settings["do_reload"] = "false"
 
 
 def main():

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -34,13 +34,15 @@ def set_theme(wallpaper, colorscheme, restore=False):
     target = colorscheme if is_file else path.join(WALL_DIR, colorscheme)
 
     set_wall = settings.getboolean("set_wallpaper", True)
+    reload_all = settings.getboolean("do_reload", True)
     colors = color.get_pywal_dict(target, is_file)
     pywal.sequences.send(colors, WPG_DIR, vte_fix=use_vte)
 
     if not restore:
         pywal.export.every(colors, FORMAT_DIR)
         color.apply_colorscheme(colors)
-        reload.all()
+        if reload_all:
+            reload.all()
     else:
         reload.xrdb()
 

--- a/wpgtk/gui/option_grid.py
+++ b/wpgtk/gui/option_grid.py
@@ -110,6 +110,14 @@ class OptionsGrid(Gtk.Grid):
         )
         self.lbl_auto_adjust = Gtk.Label("Always auto adjust")
 
+        self.reload_switch = Gtk.Switch()
+        self.reload_switch.connect(
+            "notify::active",
+            self.on_activate,
+            "do_reload"
+        )
+        self.lbl_reload = Gtk.Label("Reload system")
+
         # edit cmd
         self.editor_lbl = Gtk.Label("Open optional files with:")
         self.editor_txt = Gtk.Entry()
@@ -155,6 +163,9 @@ class OptionsGrid(Gtk.Grid):
 
         self.switch_grid.attach(self.lbl_vte, 5, 3, 3, 1)
         self.switch_grid.attach(self.vte_switch, 9, 3, 1, 1)
+
+        self.switch_grid.attach(self.lbl_reload, 5, 4, 3, 1)
+        self.switch_grid.attach(self.reload_switch, 9, 4, 1, 1)
 
         # Active Grid attach
         self.active_grid.attach(self.backend_lbl, 1, 1, 1, 1)
@@ -202,6 +213,8 @@ class OptionsGrid(Gtk.Grid):
             .set_active(settings.getboolean("smart_sort", True))
         self.auto_adjust_switch\
             .set_active(settings.getboolean("auto_adjust", False))
+        self.reload_switch\
+            .set_active(settings.getboolean("do_reload", True))
 
         self.editor_txt\
             .set_text(settings.get("editor", "urxvt -e vim"))

--- a/wpgtk/misc/wpg.conf
+++ b/wpgtk/misc/wpg.conf
@@ -10,5 +10,6 @@ backend = wal
 alpha = 100
 smart_sort = true
 auto_adjust = false
+do_reload = true
 
 [keywords]


### PR DESCRIPTION
Not sure if this is something youre interested in adding, but Im currently learning how to use wpgtk and this was a feature that I was missing since I like to perform reloads manually afterwards through my own script

Wasnt sure on what help message and gtk label to use, so consider what I have as a temp placeholder and im open to suggestions

thank you