### PR TITLE
Update gtk+ live reload to not require xsettingsd

### DIFF
--- a/wpgtk/data/reload.py
+++ b/wpgtk/data/reload.py
@@ -36,20 +36,9 @@ def openbox():
 
 
 def gtk3():
-    if shutil.which("xsettingsd") and settings.getboolean("gtk", True):
-        fd, path = tempfile.mkstemp()
-        try:
-            with os.fdopen(fd, 'w+') as tmp:
-                tmp.write('Net/ThemeName "FlatColor"\n')
-                tmp.close()
-                subprocess.call(
-                    ["timeout", "0.2s", "xsettingsd", "-c", path],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL
-                )
-        finally:
-            os.remove(path)
-
+    if settings.getboolean("gtk", True):
+        subprocess.Popen(["gsettings", "set", "org.gnome.desktop.interface", "gtk-theme", "''"])
+        subprocess.Popen(["gsettings", "set", "org.gnome.desktop.interface", "gtk-theme", "'FlatColor'"])
 
 def all():
     """Calls all possible reload methods at once."""


### PR DESCRIPTION
gsettings set instead of xsettingsd. Simpler, quicker, less hacky and requires less dependencies. Seems to work.