### PR TITLE
Allow included light pywal themes to be set

### DIFF
--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -262,7 +262,8 @@ def process_args(args):
         exit(0)
 
     if args.theme == "list":
-        name_dic = pywal.theme.list_themes()
+        dark = settings['light_theme'] != "true"
+        name_dic = pywal.theme.list_themes(dark)
         name_list = [t.name.replace(".json", "") for t in name_dic]
         print("\n".join(name_list))
         exit(0)
@@ -286,7 +287,8 @@ def process_args(args):
         exit(0)
 
     if args.theme and args.theme != "list":
-        themer.set_pywal_theme(args.theme)
+        light = settings['light_theme'] == "true"
+        themer.set_pywal_theme(args.theme, light)
         exit(0)
 
     if args.backend == "list":

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -113,10 +113,10 @@ def set_fallback_theme(wallpaper):
     return color_list
 
 
-def set_pywal_theme(theme_name):
+def set_pywal_theme(theme_name, light):
     """sets a pywal theme and applies it to wpgtk"""
     current = get_current()
-    theme = pywal.theme.file(theme_name)
+    theme = pywal.theme.file(theme_name, light)
 
     color_list = list(theme["colors"].values())
     color.write_colors(current, color_list)


### PR DESCRIPTION
This allows included light pywal themes to be set using a combination of `-L` and `--theme` flags, for example `wpg -L --theme solarized`.