### PR TITLE
Made the live gtk reload more robust.

### DIFF
--- a/wpgtk/data/reload.py
+++ b/wpgtk/data/reload.py
@@ -3,10 +3,8 @@ import subprocess
 import os
 import tempfile
 import logging
-from .util import setup_log
-setup_log()
-
 from pywal import reload
+import configparser
 
 from . import util
 from .config import FORMAT_DIR, HOME, settings
@@ -54,7 +52,6 @@ def gtk3():
         # no settings daemon is running. So GTK is getting theme info from gtkrc file
         # So using xsettingd to set the same theme (parsing it from gtkrc)
         elif shutil.which("xsettingsd") and os.path.isfile(os.path.join(os.environ.get('XDG_CONFIG_HOME'), 'gtk-3.0', 'settings.ini')):
-            import configparser
             gtkrc = configparser.ConfigParser()
             gtkrc.read(os.path.join(os.environ.get('XDG_CONFIG_HOME'), 'gtk-3.0', 'settings.ini'))
             if "Settings" in gtkrc and "gtk-theme-name" in gtkrc["Settings"]:
@@ -82,8 +79,8 @@ def gtk3():
 
         elif shutil.which("xsettingsd") and gsettings_theme:
             subprocess.Popen([
-                "gsettings", "reset",
-                "org.gnome.desktop.interface", "gtk-theme"
+                "gsettings", "set",
+                "org.gnome.desktop.interface", "gtk-theme", "''"
             ])
             subprocess.Popen([
                 "gsettings", "set",


### PR DESCRIPTION
As I said in #112 , the code now expects the user to use Flatcolor theme. And if reload GTK+ is enabled, it sets the theme to Flatcolor without even checking if the theme is installed or not. This makes the GTK live reloading kind of broken.

So I am proposing in this PR to do the following for live refreshing GTK apps.

1. If using gnome-settings-daemon.
	- If it is running, then we dont need the optional dependency xsettingsd installed and still can update the theme with just refreshing the gsettings (with the users theme even if Flatcolor is not installed)
2. If their is no settings daemon running:
	- This means GTK apps are not getting the themes info from dconf. They may get the theme from `~/.config/gtk-3.0/settings.ini` as said in case of lxappearance or other GTK theme managers.
	- So we parse the theme from those files and refresh them with xsettingsd.
3. If there is no GTK config file and no gtk-theme key in dconf, that means there is no themes set (Default Adwaita might be using) (I am not 100% sure if this case is possible, still won't hurt to leave an else clause :) )
	- In this case, we can change the theme to Flatcolor. In the commit, I did not handle if Flatcolor is not installed.
		- In this case, we can suggest the user to install Flatcolor theme from GUI etc.

A video demonstration [here](https://gfycat.com/impeccablerelievedadmiralbutterfly).

Don't know why [this issue](https://github.com/deviantfero/wpgtk/issues/174#issuecomment-622316065) #174  is closed, but it should be fixed with this I guess.

Also this PR automates exactly what you said in [this issue](https://github.com/deviantfero/wpgtk/issues/143#issuecomment-480670611) #143 : 
> If you haven't yet, you might find some help here #112, in this issue it is detailed how to do it with the gnome-settings-daemon directly, maybe that won't give you an issue, please re-open this issue if you still have an issue using `wpgtk`

N.B: I am new to GTK theming. So please review thoroughly.