### PR TITLE
Create THEMES_DIR if it doesn't exist yet

### DIFF
--- a/wpgtk/misc/wpg-install.sh
+++ b/wpgtk/misc/wpg-install.sh
@@ -140,6 +140,8 @@ install_gtk()
   echo "Installing gtk themes";
   cp -r ./FlatColor "${LOCAL}/themes/" && \
 
+  mkdir -p "${THEMES_DIR}" && \
+
   cp --remove-destination ./FlatColor/gtk-2.0/gtkrc.base "${TEMPLATE_DIR}/gtk2.base" && \
     ln -sf "${LOCAL}/themes/FlatColor/gtk-2.0/gtkrc" "${TEMPLATE_DIR}/gtk2" && \
 	ln -sf "${LOCAL}/themes/FlatColor" "${THEMES_DIR}/FlatColor" && \
@@ -168,6 +170,8 @@ install_openbox()
 {
   echo "Installing openbox themes";
   cp --remove-destination -r ./openbox/colorbamboo/* "${LOCAL}/themes/colorbamboo"
+
+  mkdir -p "${THEMES_DIR}"
 
   if [[ $? -eq 0 ]]; then
 	mv "${LOCAL}/themes/colorbamboo/openbox-3/themerc.base" "${TEMPLATE_DIR}/ob_colorbamboo.base" && \


### PR DESCRIPTION
When you run `wpg-install -gi` without a `.themes` directory in your home dir the GTK2 theme installation fails
```
Installing gtk themes
ln: failed to create symbolic link '/home/username/.themes/FlatColor': No such file or directory
:: gtk3.0 theme done
:: gtk3.20 theme done
:: FlatColor gtk themes install done.
Installing icon pack
:: flattr icons install done.
```
Running `mkdir -p .themes` fixes this issue.