### PR TITLE
Implement keyword per colorscheme feature/interface

### DIFF
--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -131,6 +131,10 @@ def read_args(args):
 
 
 def process_arg_errors(args):
+    if args.r and not args.s:
+        logging.error("invalid combination of flags, use with -s")
+        exit(1)
+
     if args.m and (args.s or args.R):
         logging.error("invalid combination of flags")
         exit(1)

--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -122,11 +122,6 @@ def read_args(args):
                         help="preview your current colorscheme",
                         action="store_true")
 
-    parser.add_argument("--update",
-                        help="update template(s) of your choice "
-                        "to the new format",
-                        nargs="+")
-
     parser.add_argument("--noreload",
                         help="Skip reloading other software after"
                         "applying colorscheme",
@@ -293,12 +288,6 @@ def process_args(args):
 
     if args.backend == "list":
         print("\n".join(pywal.colors.list_backends()))
-        exit(0)
-
-    if args.update:
-        for arg in args.update:
-            if arg.endswith(".base"):
-                files.update_template(arg)
         exit(0)
 
     if args.noreload:

--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -193,8 +193,8 @@ def process_args(args):
 
     if args.l:
         if args.t:
-            templates = files.get_file_list(OPT_DIR, False)
-            any(print(t) for t in templates if ".base" in t)
+            templates = files.get_file_list(OPT_DIR, r".*\.base$")
+            any(print(t) for t in templates)
         else:
             print("\n".join(files.get_file_list()))
         exit(0)

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -248,8 +248,10 @@ def get_color_dict(cdic):
     }
 
     try:
-        user_words = {k: v.format(**all_colors)
-                      for k, v in user_keywords.items()}
+        user_words = {
+            k: v.format(**all_colors)
+            for k, v in user_keywords.items()
+        }
         all_colors = {**all_colors, **user_words}
 
     except KeyError as e:

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -170,8 +170,7 @@ def auto_adjust(colors):
 def change_templates(colors):
     """call change_colors on each custom template
     installed or defined by the user"""
-    templates = files.get_file_list(OPT_DIR, images=False)
-    templates = [x for x in templates if ".base" in x]
+    templates = files.get_file_list(OPT_DIR, r".*\.base$")
 
     try:
         for template in templates:

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -238,7 +238,7 @@ def get_color_dict(pywal_colors, colorscheme):
 
     base_color = pywal_colors["colors"]["color%s" % index]
     color_list = list(pywal_colors["colors"].values())
-    key_parser = keywords.get_keywords_parser(colorscheme)
+    keyword_dict = keywords.get_keywords_section(colorscheme)
 
     all_colors = {
         "wallpaper": pywal_colors["wallpaper"],
@@ -252,7 +252,7 @@ def get_color_dict(pywal_colors, colorscheme):
     try:
         user_words = {
             k: v.format(**all_colors)
-            for k, v in key_parser['keywords'].items()
+            for k, v in keyword_dict.items()
         }
         all_colors = {**all_colors, **user_words}
 

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -233,12 +233,13 @@ def keyword_colors(hexc, is_dark_theme=True):
 
 def get_color_dict(pywal_colors, colorscheme):
     """ensamble wpgtk color dictionary from pywal color dictionary"""
+    keyword_set = settings.get('keywords', 'default')
     index = settings.getint("active")
     index = index if index > 0 else randint(9, 14)
 
     base_color = pywal_colors["colors"]["color%s" % index]
     color_list = list(pywal_colors["colors"].values())
-    keyword_dict = keywords.get_keywords_section(colorscheme)
+    keyword_dict = keywords.get_keywords_section(keyword_set)
 
     all_colors = {
         "wallpaper": pywal_colors["wallpaper"],
@@ -249,18 +250,20 @@ def get_color_dict(pywal_colors, colorscheme):
         **keyword_colors(base_color, is_dark_theme(color_list))
     }
 
+    all_colors = {
+        k: pywal.util.Color(v) for k, v in all_colors.items()
+    }
+
     try:
         user_words = {
-            k: v.format(**all_colors)
+            k: pywal.util.Color(v.format_map(all_colors))
             for k, v in keyword_dict.items()
         }
-        all_colors = {**all_colors, **user_words}
-
     except KeyError as e:
         logging.error("%s - invalid, use double {{}} "
                       "to escape curly braces" % e)
 
-    return {k: pywal.util.Color(v) for k, v in all_colors.items()}
+    return {**all_colors, **user_words}
 
 
 def apply_colorscheme(color_dict):

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -261,9 +261,10 @@ def get_color_dict(cdic):
     return {k: pywal.util.Color(v) for k, v in all_colors.items()}
 
 
-def apply_colorscheme(colors):
-    color_dict = get_color_dict(colors)
-
+def apply_colorscheme(color_dict):
+    """Receives a colorscheme dict ensambled by
+    color.get_color_dict as argument and applies it
+    system-wide."""
     if os.path.isfile(FILE_DIC["icon-step2"]):
         change_colors(color_dict, "icon-step1")
         Popen(FILE_DIC["icon-step2"])

--- a/wpgtk/data/color.py
+++ b/wpgtk/data/color.py
@@ -8,8 +8,9 @@ from operator import itemgetter
 from subprocess import Popen
 from random import shuffle, randint
 
-from .config import settings, user_keywords
+from .config import settings
 from .config import WALL_DIR, WPG_DIR, FILE_DIC, OPT_DIR
+from . import keywords
 from . import files
 from . import util
 from . import sample
@@ -230,27 +231,28 @@ def keyword_colors(hexc, is_dark_theme=True):
     }
 
 
-def get_color_dict(cdic):
-    """ensamble wpgtk color dictionary"""
+def get_color_dict(pywal_colors, colorscheme):
+    """ensamble wpgtk color dictionary from pywal color dictionary"""
     index = settings.getint("active")
     index = index if index > 0 else randint(9, 14)
 
-    base_color = cdic["colors"]["color%s" % index]
-    color_list = list(cdic["colors"].values())
+    base_color = pywal_colors["colors"]["color%s" % index]
+    color_list = list(pywal_colors["colors"].values())
+    key_parser = keywords.get_keywords_parser(colorscheme)
 
     all_colors = {
-        "wallpaper": cdic["wallpaper"],
-        "alpha": cdic["alpha"],
-        **cdic["special"],
-        **cdic["colors"],
-        **add_icon_colors(cdic),
+        "wallpaper": pywal_colors["wallpaper"],
+        "alpha": pywal_colors["alpha"],
+        **pywal_colors["special"],
+        **pywal_colors["colors"],
+        **add_icon_colors(pywal_colors),
         **keyword_colors(base_color, is_dark_theme(color_list))
     }
 
     try:
         user_words = {
             k: v.format(**all_colors)
-            for k, v in user_keywords.items()
+            for k, v in key_parser['keywords'].items()
         }
         all_colors = {**all_colors, **user_words}
 

--- a/wpgtk/data/config.py
+++ b/wpgtk/data/config.py
@@ -3,7 +3,7 @@ import shutil
 import os
 import logging
 
-__version__ = '6.2.3'
+__version__ = '6.5.0'
 
 settings = None
 

--- a/wpgtk/data/config.py
+++ b/wpgtk/data/config.py
@@ -19,6 +19,7 @@ CONF_BACKUP = os.path.join(MODULE_DIR, "misc/wpg.conf")
 WALL_DIR = os.path.join(WPG_DIR, "wallpapers")
 SAMPLE_DIR = os.path.join(WPG_DIR, "samples")
 SCHEME_DIR = os.path.join(WPG_DIR, "schemes")
+KEYWORD_DIR = os.path.join(WPG_DIR, "keywords")
 FORMAT_DIR = os.path.join(CACHE, "wal")
 OPT_DIR = os.path.join(WPG_DIR, "templates")
 FILE_DIC = {
@@ -52,6 +53,7 @@ def load_settings():
     os.makedirs(SAMPLE_DIR, exist_ok=True)
     os.makedirs(SCHEME_DIR, exist_ok=True)
     os.makedirs(FORMAT_DIR, exist_ok=True)
+    os.makedirs(KEYWORD_DIR, exist_ok=True)
     os.makedirs(OPT_DIR, exist_ok=True)
 
     try:

--- a/wpgtk/data/config.py
+++ b/wpgtk/data/config.py
@@ -14,12 +14,12 @@ LOCAL = os.getenv("XDG_DATA_HOME", os.path.join(HOME, ".local", "share"))
 
 WPG_DIR = os.path.join(CONFIG, "wpg")
 CONF_FILE = os.path.join(WPG_DIR, "wpg.conf")
+KEYWORD_FILE = os.path.join(WPG_DIR, "keywords.conf")
 MODULE_DIR = os.path.abspath(os.path.join(__file__, "../../"))
 CONF_BACKUP = os.path.join(MODULE_DIR, "misc/wpg.conf")
 WALL_DIR = os.path.join(WPG_DIR, "wallpapers")
 SAMPLE_DIR = os.path.join(WPG_DIR, "samples")
 SCHEME_DIR = os.path.join(WPG_DIR, "schemes")
-KEYWORD_DIR = os.path.join(WPG_DIR, "keywords")
 FORMAT_DIR = os.path.join(CACHE, "wal")
 OPT_DIR = os.path.join(WPG_DIR, "templates")
 FILE_DIC = {
@@ -36,16 +36,45 @@ def write_conf(config_path=CONF_FILE):
     with open(config_path, 'w') as config_file:
         parser.write(config_file)
 
+def write_keywords(keywords_path=KEYWORD_FILE):
+    global keywords_parser
+
+    with open(keywords_path, 'w') as keywords_file:
+        keywords_parser.write(keywords_file)
+
 
 def load_sections():
     """reads the sections of the config file"""
     global parser
+    global keywords_parser
 
+    parser = load_config()
+    keywords_parser = load_keywords()
+
+    return [parser['settings'], keywords_parser]
+
+def load_config():
     parser = configparser.ConfigParser()
     parser.optionxform = str
     parser.read(CONF_FILE)
 
-    return [parser['settings'], parser['keywords']]
+    return parser
+
+def load_keywords():
+    if not os.path.exists(KEYWORD_FILE):
+        open(KEYWORD_FILE, 'a').close()
+
+    keywords_parser = configparser.ConfigParser()
+    keywords_parser.optionxform = str
+    keywords_parser.read(KEYWORD_FILE)
+
+    if not keywords_parser.has_section('default'):
+        keywords_parser.add_section('default')
+
+        with open(KEYWORD_FILE, 'w') as f:
+            keywords_parser.write(f)
+
+    return keywords_parser
 
 
 def load_settings():
@@ -53,7 +82,6 @@ def load_settings():
     os.makedirs(SAMPLE_DIR, exist_ok=True)
     os.makedirs(SCHEME_DIR, exist_ok=True)
     os.makedirs(FORMAT_DIR, exist_ok=True)
-    os.makedirs(KEYWORD_DIR, exist_ok=True)
     os.makedirs(OPT_DIR, exist_ok=True)
 
     try:

--- a/wpgtk/data/files.py
+++ b/wpgtk/data/files.py
@@ -72,14 +72,10 @@ def get_sample_path(wallpaper, backend=None):
     return join(SAMPLE_DIR, sample_filename)
 
 
-def get_keywords_path(wallpaper, backend=None):
+def get_keywords_path(filename):
     """gets the path of the keywords file of a theme"""
-    if not backend:
-        backend = settings.get("backend", "wal")
 
-    keywords_filename = "%s_%s_keywords.conf" % (wallpaper, backend)
-
-    return join(KEYWORD_DIR, keywords_filename)
+    return join(KEYWORD_DIR, filename)
 
 
 def add_template(cfile, bfile=None):
@@ -127,7 +123,6 @@ def delete_colorschemes(colorscheme):
         try:
             os.remove(get_cache_path(colorscheme, backend))
             os.remove(get_sample_path(colorscheme, backend))
-            os.remove(get_keywords_path(colorscheme, backend))
         except OSError:
             pass
 

--- a/wpgtk/data/files.py
+++ b/wpgtk/data/files.py
@@ -12,7 +12,6 @@ from .config import (
     WPG_DIR,
     OPT_DIR,
     SAMPLE_DIR,
-    KEYWORD_FILE
 )
 
 

--- a/wpgtk/data/files.py
+++ b/wpgtk/data/files.py
@@ -72,6 +72,16 @@ def get_sample_path(wallpaper, backend=None):
     return join(SAMPLE_DIR, sample_filename)
 
 
+def get_keywords_path(wallpaper, backend=None):
+    """gets the path of the keywords file of a theme"""
+    if not backend:
+        backend = settings.get("backend", "wal")
+
+    keywords_filename = "%s_%s_keywords.conf" % (wallpaper, backend)
+
+    return join(KEYWORD_DIR, keywords_filename)
+
+
 def add_template(cfile, bfile=None):
     """adds a new base file from a config file to wpgtk
     or re-establishes link with config file for a
@@ -111,12 +121,13 @@ def delete_template(basefile):
         logging.error(str(e.strerror))
 
 
-def delete_colorschemes(wallpaper):
-    """delete all colorschemes related to the given wallpaper"""
+def delete_colorschemes(colorscheme):
+    """delete all files related to the given colorscheme"""
     for backend in list_backends():
         try:
-            os.remove(get_cache_path(wallpaper, backend))
-            os.remove(get_sample_path(wallpaper, backend))
+            os.remove(get_cache_path(colorscheme, backend))
+            os.remove(get_sample_path(colorscheme, backend))
+            os.remove(get_keywords_path(colorscheme, backend))
         except OSError:
             pass
 

--- a/wpgtk/data/files.py
+++ b/wpgtk/data/files.py
@@ -121,32 +121,6 @@ def delete_colorschemes(wallpaper):
             pass
 
 
-def update_color(matchobj):
-    if matchobj.group(1):
-        return "{%s}" % matchobj.group(1).lower()
-
-
-def update_template(template_path):
-    tmp_data = ""
-
-    with open(template_path, "r") as f:
-        tmp_data = f.read()
-
-        logging.info("escaping legitimate curly braces {} -> {{}}")
-        tmp_data = tmp_data.replace("{", "{{")
-        tmp_data = tmp_data.replace("}", "}}")
-
-        logging.info("replacing #<COLORXX> with braces {colorxx}")
-        tmp_data = re.sub(r"#<(COLOR[0-9]{1,2})>", update_color, tmp_data)
-        tmp_data = tmp_data.replace("#<COLORACT>", "{active}")
-        tmp_data = tmp_data.replace("#<COLORIN>", "{inactive}")
-
-    with open(template_path, "w") as f:
-        logging.info("writting %s" % template_path)
-        f.write(tmp_data)
-        logging.info("%s update complete" % template_path)
-
-
 def change_current(filename):
     """update symlink to point to the current wallpaper"""
     os.symlink(join(WALL_DIR, filename), join(WPG_DIR, ".currentTmp"))

--- a/wpgtk/data/files.py
+++ b/wpgtk/data/files.py
@@ -2,18 +2,27 @@ import os
 import shutil
 import re
 import logging
+from subprocess import Popen
 from pywal.colors import cache_fname, list_backends
 
-from .config import settings, WALL_DIR, WPG_DIR, OPT_DIR, SAMPLE_DIR
 from os.path import join, basename
+from .config import (
+    settings,
+    WALL_DIR,
+    WPG_DIR,
+    OPT_DIR,
+    SAMPLE_DIR,
+    KEYWORD_DIR
+)
 
 
 def get_file_list(path=WALL_DIR, images=True):
     """gets filenames in a given directory, optional
     parameters for image filter."""
 
-    valid = re.compile(r"^[^\.](.*\.png$|.*\.jpg$|.*\.jpeg$|.*\.jpe$|.*\.gif$)")
     files = []
+    valid = re.compile(
+        r"^[^\.](.*\.png$|.*\.jpg$|.*\.jpeg$|.*\.jpe$|.*\.gif$)")
 
     for _, _, filenames in os.walk(path):
         files.extend(filenames)
@@ -39,6 +48,7 @@ def write_script(wallpaper, colorscheme):
     with open(join(WPG_DIR, "wp_init.sh"), "w") as script:
         command = "wpg %s '%s' '%s'" % (flags, wallpaper, colorscheme)
         script.writelines(["#!/usr/bin/env bash\n", command])
+        Popen(['chmod', '+x', join(WPG_DIR, "wp_init.sh")])
 
 
 def get_cache_path(wallpaper, backend=None):
@@ -79,8 +89,7 @@ def add_template(cfile, bfile=None):
         src_file = bfile if bfile else cfile
 
         shutil.copy2(src_file, join(OPT_DIR, template_name))
-        os.symlink(cfile, join(OPT_DIR,
-                               template_name.replace(".base", "")))
+        os.symlink(cfile, join(OPT_DIR, template_name.replace(".base", "")))
 
         logging.info("created backup %s.bak" % cfile)
         logging.info("added %s @ %s" % (template_name, cfile))

--- a/wpgtk/data/files.py
+++ b/wpgtk/data/files.py
@@ -15,13 +15,11 @@ from .config import (
 )
 
 
-def get_file_list(path=WALL_DIR, images=True):
-    """gets filenames in a given directory, optional
-    parameters for image filter."""
+def get_file_list(path=WALL_DIR, regex=None):
+    """gets file names in a given directory, optional regex
+    parameter to filter the list of files by."""
 
     files = []
-    valid = re.compile(
-        r"^[^\.](.*\.png$|.*\.jpg$|.*\.jpeg$|.*\.jpe$|.*\.gif$)")
 
     for _, _, filenames in os.walk(path):
         files.extend(filenames)
@@ -29,7 +27,8 @@ def get_file_list(path=WALL_DIR, images=True):
 
     files.sort()
 
-    if images:
+    if regex is not None:
+        valid = re.compile(regex)
         return [elem for elem in files if valid.fullmatch(elem)]
     else:
         return files

--- a/wpgtk/data/files.py
+++ b/wpgtk/data/files.py
@@ -12,7 +12,7 @@ from .config import (
     WPG_DIR,
     OPT_DIR,
     SAMPLE_DIR,
-    KEYWORD_DIR
+    KEYWORD_FILE
 )
 
 
@@ -70,12 +70,6 @@ def get_sample_path(wallpaper, backend=None):
     sample_filename = "%s_%s_sample.png" % (wallpaper, backend)
 
     return join(SAMPLE_DIR, sample_filename)
-
-
-def get_keywords_path(filename):
-    """gets the path of the keywords file of a theme"""
-
-    return join(KEYWORD_DIR, filename)
 
 
 def add_template(cfile, bfile=None):

--- a/wpgtk/data/keywords.py
+++ b/wpgtk/data/keywords.py
@@ -1,41 +1,90 @@
-from .config import user_keywords, write_conf
+import configparser
+from os import path
+
+from .config import user_keywords
+from .files import get_keywords_path
 
 KEY_LENGTH = 5
 VAL_LENGTH = 2
 
 
-def update_key(old_keyword, new_keyword, save=False):
-    """validates and updates a keyword"""
+def create_keywords_file(colorscheme):
+    """creates a new keywords file and sets defaults if they exist"""
+    parser = configparser.ConfigParser()
+    parser.add_section('keywords')
+
+    for k, v in dict(user_keywords):
+        parser['keywords'][k] = v
+
+    with open(get_keywords_path(colorscheme), "w") as keyword_file:
+        parser.write(keyword_file)
+
+    return parser
+
+
+def get_keywords_parser(colorscheme):
+    """get keyword file configparser for current wallpaper
+       or create one if it does not exist"""
+
+    if path.isfile(get_keywords_path(colorscheme)):
+        parser = configparser.ConfigParser()
+        parser.read(get_keywords_path(colorscheme))
+
+        return parser
+
+    else:
+        return create_keywords_file(colorscheme)
+
+
+def update_key(colorscheme, old_keyword, new_keyword):
+    """validates and updates a keyword for a wallpaper"""
     if not new_keyword:
         raise Exception('Keyword must be longer than 5 characters')
 
-    user_keywords[new_keyword] = user_keywords[old_keyword]
+    parser = get_keywords_parser(colorscheme) if colorscheme else user_keywords
+    keywords = parser['keywords']
+    keywords[new_keyword] = keywords[old_keyword]
 
-    if(old_keyword != new_keyword):
-        user_keywords.pop(old_keyword, None)
+    if (old_keyword != new_keyword):
+        keywords.pop(old_keyword, None)
 
-    if save:
-        write_conf()
+    with open(get_keywords_path(colorscheme), "w") as keyword_file:
+        parser.write(keyword_file)
 
 
-def update_value(keyword, value, save=False):
+def update_value(colorscheme, keyword, value):
+    """update the value to replace the user defined keyword with"""
     if not value:
         raise Exception('Value must exist')
 
-    user_keywords[keyword] = value
+    parser = get_keywords_parser(colorscheme)
+    keywords = parser['keywords']
+    keywords[keyword] = value
 
-    if save:
-        write_conf()
+    with open(get_keywords_path(colorscheme), "w") as keyword_file:
+        parser.write(keyword_file)
 
 
-def create_pair(keyword, value, save=False):
+def create_pair(colorscheme, keyword, value):
+    """create a key value pair for a wallpaper"""
     if not value:
         raise Exception('There must be a value')
 
     if not keyword:
-        raise Exception('There must be a value')
+        raise Exception('There must be a keyword')
 
-    user_keywords[keyword] = value
+    parser = get_keywords_parser(colorscheme)
+    parser['keywords'][keyword] = value
 
-    if save:
-        write_conf()
+    with open(get_keywords_path(colorscheme), "w") as keyword_file:
+        parser.write(keyword_file)
+
+
+def remove_pair(colorscheme, keyword):
+    """removes a pair of keyword value for a wallpaper"""
+
+    parser = get_keywords_parser(colorscheme)
+    parser['keywords'].pop(keyword, None)
+
+    with open(get_keywords_path(colorscheme), "w") as keyword_file:
+        parser.write(keyword_file)

--- a/wpgtk/data/keywords.py
+++ b/wpgtk/data/keywords.py
@@ -8,7 +8,7 @@ KEY_LENGTH = 5
 VAL_LENGTH = 2
 
 
-def create_keywords_file(colorscheme):
+def create_keywords_file(filename):
     """creates a new keywords file and sets defaults if they exist"""
     parser = configparser.ConfigParser()
     parser.add_section('keywords')
@@ -16,54 +16,54 @@ def create_keywords_file(colorscheme):
     for k, v in dict(user_keywords):
         parser['keywords'][k] = v
 
-    with open(get_keywords_path(colorscheme), "w") as keyword_file:
+    with open(get_keywords_path(filename), "w") as keyword_file:
         parser.write(keyword_file)
 
-    return get_keywords_path(colorscheme)
+    return get_keywords_path(filename)
 
 
-def get_keywords_section(colorscheme):
+def get_keywords_section(filename = None):
     """get keyword file configparser for current wallpaper
        or create one if it does not exist"""
-
-    if colorscheme is None:
+    if filename is None:
         return user_keywords
 
     parser = configparser.ConfigParser()
 
-    if not path.isfile(get_keywords_path(colorscheme)):
-        create_keywords_file(colorscheme)
+    if not path.isfile(get_keywords_path(filename)):
+        create_keywords_file(filename)
 
-    parser.read(get_keywords_path(colorscheme))
+    parser.read(get_keywords_path(filename))
+
     return parser['keywords']
 
 
-def update_key(old_keyword, new_keyword, colorscheme=None):
+def update_key(old_keyword, new_keyword, filename=None):
     """validates and updates a keyword for a wallpaper"""
     if not new_keyword:
         raise Exception('Keyword must be longer than 5 characters')
 
-    keywords = get_keywords_section(colorscheme)
+    keywords = get_keywords_section(filename)
     keywords[new_keyword] = keywords[old_keyword]
 
     if (old_keyword != new_keyword):
         keywords.pop(old_keyword, None)
 
-    write_keyword_file(keywords, colorscheme)
+    write_keyword_file(keywords, filename)
 
 
-def update_value(keyword, value, colorscheme=None):
+def update_value(keyword, value, filename=None):
     """update the value to replace the user defined keyword with"""
     if not value:
         raise Exception('Value must exist')
 
-    keywords = get_keywords_section(colorscheme)
+    keywords = get_keywords_section(filename)
     keywords[keyword] = value
 
-    write_keyword_file(keywords, colorscheme)
+    write_keyword_file(keywords, filename)
 
 
-def create_pair(keyword, value, colorscheme=None):
+def create_pair(keyword, value, filename=None):
     """create a key value pair for a wallpaper"""
     if not value:
         raise Exception('There must be a value')
@@ -71,24 +71,24 @@ def create_pair(keyword, value, colorscheme=None):
     if not keyword:
         raise Exception('There must be a keyword')
 
-    keywords = get_keywords_section(colorscheme)
+    keywords = get_keywords_section(filename)
     keywords[keyword] = value
 
-    write_keyword_file(keywords, colorscheme)
+    write_keyword_file(keywords, filename)
 
 
-def remove_pair(keyword, colorscheme=None):
+def remove_pair(keyword, filename=None):
     """removes a pair of keyword value for a wallpaper"""
 
-    keywords = get_keywords_section(colorscheme)
+    keywords = get_keywords_section(filename)
     keywords.pop(keyword, None)
 
-    write_keyword_file(keywords, colorscheme)
+    write_keyword_file(keywords, filename)
 
 
-def write_keyword_file(keywords, colorscheme=None):
-    if colorscheme:
-        keywords_path = get_keywords_path(colorscheme)
+def write_keyword_file(keywords, filename=None):
+    if filename:
+        keywords_path = get_keywords_path(filename)
         parser = configparser.ConfigParser()
         parser['keywords'] = keywords
 

--- a/wpgtk/data/keywords.py
+++ b/wpgtk/data/keywords.py
@@ -1,30 +1,28 @@
-import configparser
-from os import path
-
 from .config import user_keywords, write_keywords
 
 KEY_LENGTH = 5
 VAL_LENGTH = 2
 
 
-def get_keywords_section(theme = None):
+def delete_keywords_section(name):
+    if name != 'default':
+        user_keywords.remove_section(name)
+        write_keywords()
+
+
+def create_keywords_section(name):
+    user_keywords.add_section(name)
+    write_keywords()
+
+
+def get_keywords_section(theme):
     """get keyword file configparser for current wallpaper
        or create one if it does not exist"""
-    if theme is None:
-        return user_keywords['default']
-
     if not user_keywords.has_section(theme):
-        user_keywords.add_section(theme)
-        user_keywords[theme] = user_keywords['default']
+        create_keywords_section(theme)
 
     return user_keywords[theme]
 
-def reset_keywords_section(theme):
-    """set the theme's keyword to the default key value pairs"""
-
-    if user_keywords.has_section(theme):
-        user_keywords[theme] = user_keywords['default']
-        write_keywords()
 
 def update_key(old_keyword, new_keyword, theme=None):
     """validates and updates a keyword for a wallpaper"""
@@ -40,7 +38,7 @@ def update_key(old_keyword, new_keyword, theme=None):
     write_keywords()
 
 
-def update_value(keyword, value, theme=None):
+def update_value(keyword, value, theme):
     """update the value to replace the user defined keyword with"""
     if not value:
         raise Exception('Value must exist')
@@ -51,7 +49,7 @@ def update_value(keyword, value, theme=None):
     write_keywords()
 
 
-def create_pair(keyword, value, theme=None):
+def create_pair(keyword, value, theme):
     """create a key value pair for a wallpaper"""
     if not value:
         raise Exception('There must be a value')
@@ -65,9 +63,8 @@ def create_pair(keyword, value, theme=None):
     write_keywords()
 
 
-def remove_pair(keyword, theme=None):
+def remove_pair(keyword, theme):
     """removes a pair of keyword value for a wallpaper"""
-
     keywords = get_keywords_section(theme)
     keywords.pop(keyword, None)
 

--- a/wpgtk/data/keywords.py
+++ b/wpgtk/data/keywords.py
@@ -65,7 +65,6 @@ def update_value(keyword, value, colorscheme=None):
 
 def create_pair(keyword, value, colorscheme=None):
     """create a key value pair for a wallpaper"""
-    print('hi', keyword, value, colorscheme)
     if not value:
         raise Exception('There must be a value')
 

--- a/wpgtk/data/keywords.py
+++ b/wpgtk/data/keywords.py
@@ -1,69 +1,57 @@
 import configparser
 from os import path
 
-from .config import user_keywords, write_conf
-from .files import get_keywords_path
+from .config import user_keywords, write_keywords
 
 KEY_LENGTH = 5
 VAL_LENGTH = 2
 
 
-def create_keywords_file(filename):
-    """creates a new keywords file and sets defaults if they exist"""
-    parser = configparser.ConfigParser()
-    parser.add_section('keywords')
-
-    for k, v in dict(user_keywords):
-        parser['keywords'][k] = v
-
-    with open(get_keywords_path(filename), "w") as keyword_file:
-        parser.write(keyword_file)
-
-    return get_keywords_path(filename)
-
-
-def get_keywords_section(filename = None):
+def get_keywords_section(theme = None):
     """get keyword file configparser for current wallpaper
        or create one if it does not exist"""
-    if filename is None:
-        return user_keywords
+    if theme is None:
+        return user_keywords['default']
 
-    parser = configparser.ConfigParser()
+    if not user_keywords.has_section(theme):
+        user_keywords.add_section(theme)
+        user_keywords[theme] = user_keywords['default']
 
-    if not path.isfile(get_keywords_path(filename)):
-        create_keywords_file(filename)
+    return user_keywords[theme]
 
-    parser.read(get_keywords_path(filename))
+def reset_keywords_section(theme):
+    """set the theme's keyword to the default key value pairs"""
 
-    return parser['keywords']
+    if user_keywords.has_section(theme):
+        user_keywords[theme] = user_keywords['default']
+        write_keywords()
 
-
-def update_key(old_keyword, new_keyword, filename=None):
+def update_key(old_keyword, new_keyword, theme=None):
     """validates and updates a keyword for a wallpaper"""
     if not new_keyword:
         raise Exception('Keyword must be longer than 5 characters')
 
-    keywords = get_keywords_section(filename)
+    keywords = get_keywords_section(theme)
     keywords[new_keyword] = keywords[old_keyword]
 
     if (old_keyword != new_keyword):
         keywords.pop(old_keyword, None)
 
-    write_keyword_file(keywords, filename)
+    write_keywords()
 
 
-def update_value(keyword, value, filename=None):
+def update_value(keyword, value, theme=None):
     """update the value to replace the user defined keyword with"""
     if not value:
         raise Exception('Value must exist')
 
-    keywords = get_keywords_section(filename)
+    keywords = get_keywords_section(theme)
     keywords[keyword] = value
 
-    write_keyword_file(keywords, filename)
+    write_keywords()
 
 
-def create_pair(keyword, value, filename=None):
+def create_pair(keyword, value, theme=None):
     """create a key value pair for a wallpaper"""
     if not value:
         raise Exception('There must be a value')
@@ -71,28 +59,16 @@ def create_pair(keyword, value, filename=None):
     if not keyword:
         raise Exception('There must be a keyword')
 
-    keywords = get_keywords_section(filename)
+    keywords = get_keywords_section(theme)
     keywords[keyword] = value
 
-    write_keyword_file(keywords, filename)
+    write_keywords()
 
 
-def remove_pair(keyword, filename=None):
+def remove_pair(keyword, theme=None):
     """removes a pair of keyword value for a wallpaper"""
 
-    keywords = get_keywords_section(filename)
+    keywords = get_keywords_section(theme)
     keywords.pop(keyword, None)
 
-    write_keyword_file(keywords, filename)
-
-
-def write_keyword_file(keywords, filename=None):
-    if filename:
-        keywords_path = get_keywords_path(filename)
-        parser = configparser.ConfigParser()
-        parser['keywords'] = keywords
-
-        with open(keywords_path, "w") as keyword_file:
-            parser.write(keyword_file)
-    else:
-        write_conf()
+    write_keywords()

--- a/wpgtk/data/keywords.py
+++ b/wpgtk/data/keywords.py
@@ -26,6 +26,10 @@ def get_keywords_parser(colorscheme):
     """get keyword file configparser for current wallpaper
        or create one if it does not exist"""
 
+    if colorscheme == None:
+        parser = user_keywords
+        return parser
+
     if path.isfile(get_keywords_path(colorscheme)):
         parser = configparser.ConfigParser()
         parser.read(get_keywords_path(colorscheme))
@@ -57,7 +61,7 @@ def update_value(colorscheme, keyword, value):
     if not value:
         raise Exception('Value must exist')
 
-    parser = get_keywords_parser(colorscheme)
+    parser = get_keywords_parser(colorscheme) if colorscheme else user_keywords
     keywords = parser['keywords']
     keywords[keyword] = value
 
@@ -73,7 +77,7 @@ def create_pair(colorscheme, keyword, value):
     if not keyword:
         raise Exception('There must be a keyword')
 
-    parser = get_keywords_parser(colorscheme)
+    parser = get_keywords_parser(colorscheme) if colorscheme else user_keywords
     parser['keywords'][keyword] = value
 
     with open(get_keywords_path(colorscheme), "w") as keyword_file:
@@ -83,7 +87,7 @@ def create_pair(colorscheme, keyword, value):
 def remove_pair(colorscheme, keyword):
     """removes a pair of keyword value for a wallpaper"""
 
-    parser = get_keywords_parser(colorscheme)
+    parser = get_keywords_parser(colorscheme) if colorscheme else user_keywords
     parser['keywords'].pop(keyword, None)
 
     with open(get_keywords_path(colorscheme), "w") as keyword_file:

--- a/wpgtk/data/keywords.py
+++ b/wpgtk/data/keywords.py
@@ -1,7 +1,7 @@
 import configparser
 from os import path
 
-from .config import user_keywords
+from .config import user_keywords, write_conf
 from .files import get_keywords_path
 
 KEY_LENGTH = 5
@@ -19,76 +19,81 @@ def create_keywords_file(colorscheme):
     with open(get_keywords_path(colorscheme), "w") as keyword_file:
         parser.write(keyword_file)
 
-    return parser
+    return get_keywords_path(colorscheme)
 
 
-def get_keywords_parser(colorscheme):
+def get_keywords_section(colorscheme):
     """get keyword file configparser for current wallpaper
        or create one if it does not exist"""
 
-    if colorscheme == None:
-        parser = user_keywords
-        return parser
+    if colorscheme is None:
+        return user_keywords
 
-    if path.isfile(get_keywords_path(colorscheme)):
-        parser = configparser.ConfigParser()
-        parser.read(get_keywords_path(colorscheme))
+    parser = configparser.ConfigParser()
 
-        return parser
+    if not path.isfile(get_keywords_path(colorscheme)):
+        create_keywords_file(colorscheme)
 
-    else:
-        return create_keywords_file(colorscheme)
+    parser.read(get_keywords_path(colorscheme))
+    return parser['keywords']
 
 
-def update_key(colorscheme, old_keyword, new_keyword):
+def update_key(old_keyword, new_keyword, colorscheme=None):
     """validates and updates a keyword for a wallpaper"""
     if not new_keyword:
         raise Exception('Keyword must be longer than 5 characters')
 
-    parser = get_keywords_parser(colorscheme) if colorscheme else user_keywords
-    keywords = parser['keywords']
+    keywords = get_keywords_section(colorscheme)
     keywords[new_keyword] = keywords[old_keyword]
 
     if (old_keyword != new_keyword):
         keywords.pop(old_keyword, None)
 
-    with open(get_keywords_path(colorscheme), "w") as keyword_file:
-        parser.write(keyword_file)
+    write_keyword_file(keywords, colorscheme)
 
 
-def update_value(colorscheme, keyword, value):
+def update_value(keyword, value, colorscheme=None):
     """update the value to replace the user defined keyword with"""
     if not value:
         raise Exception('Value must exist')
 
-    parser = get_keywords_parser(colorscheme) if colorscheme else user_keywords
-    keywords = parser['keywords']
+    keywords = get_keywords_section(colorscheme)
     keywords[keyword] = value
 
-    with open(get_keywords_path(colorscheme), "w") as keyword_file:
-        parser.write(keyword_file)
+    write_keyword_file(keywords, colorscheme)
 
 
-def create_pair(colorscheme, keyword, value):
+def create_pair(keyword, value, colorscheme=None):
     """create a key value pair for a wallpaper"""
+    print('hi', keyword, value, colorscheme)
     if not value:
         raise Exception('There must be a value')
 
     if not keyword:
         raise Exception('There must be a keyword')
 
-    parser = get_keywords_parser(colorscheme) if colorscheme else user_keywords
-    parser['keywords'][keyword] = value
+    keywords = get_keywords_section(colorscheme)
+    keywords[keyword] = value
 
-    with open(get_keywords_path(colorscheme), "w") as keyword_file:
-        parser.write(keyword_file)
+    write_keyword_file(keywords, colorscheme)
 
 
-def remove_pair(colorscheme, keyword):
+def remove_pair(keyword, colorscheme=None):
     """removes a pair of keyword value for a wallpaper"""
 
-    parser = get_keywords_parser(colorscheme) if colorscheme else user_keywords
-    parser['keywords'].pop(keyword, None)
+    keywords = get_keywords_section(colorscheme)
+    keywords.pop(keyword, None)
 
-    with open(get_keywords_path(colorscheme), "w") as keyword_file:
-        parser.write(keyword_file)
+    write_keyword_file(keywords, colorscheme)
+
+
+def write_keyword_file(keywords, colorscheme=None):
+    if colorscheme:
+        keywords_path = get_keywords_path(colorscheme)
+        parser = configparser.ConfigParser()
+        parser['keywords'] = keywords
+
+        with open(keywords_path, "w") as keyword_file:
+            parser.write(keyword_file)
+    else:
+        write_conf()

--- a/wpgtk/data/reload.py
+++ b/wpgtk/data/reload.py
@@ -82,26 +82,29 @@ def gtk3():
     # So GTK is getting theme info from gtkrc file
     # using xsettingd to set the same theme (parsing it from gtkrc)
     elif shutil.which("xsettingsd") and os.path.isfile(settings_ini):
-        gtkrc = configparser.ConfigParser()
-        gtkrc.read(settings_ini)
+        theme = "FlatColor"
 
-        if gtkrc["Settings"]:
-            theme = gtkrc["Settings"].get("gtk-theme-name", "FlatColor")
+        if os.path.isfile(settings_ini):
+            gtkrc = configparser.ConfigParser()
+            gtkrc.read(settings_ini)
+
+            if gtkrc["Settings"]:
+                theme = gtkrc["Settings"].get("gtk-theme-name", "FlatColor")
+
+        try:
             fd, path = tempfile.mkstemp()
-
-            try:
-                with os.fdopen(fd, "w+") as tmp:
-                    tmp.write('Net/ThemeName "' + theme + '"\n')
-                    tmp.close()
-                    util.silent_call([
-                        "timeout", "0.2s", "xsettingsd", "-c", path
-                    ])
-                logging.info(
-                    "reloaded %s from settings.ini using xsettingsd"
-                    % theme
-                )
-            finally:
-                os.remove(path)
+            with os.fdopen(fd, "w+") as tmp:
+                tmp.write('Net/ThemeName "' + theme + '"\n')
+                tmp.close()
+                util.silent_Popen([
+                    "xsettingsd", "-c", path
+                ])
+            logging.info(
+                "reloaded %s from settings.ini using xsettingsd"
+                % theme
+            )
+        finally:
+            os.remove(path)
 
     # The system has no known settings daemon installed,
     # but dconf gtk-theme exists, just refreshing its theme

--- a/wpgtk/data/sample.py
+++ b/wpgtk/data/sample.py
@@ -10,6 +10,7 @@ except ImportError:
 
 
 def create_sample(colors, f=os.path.join(WALL_DIR, ".tmp.sample.png")):
+    """Creates sample image from a pywal color dictionary"""
     im = Image.new("RGB", (480, 50), "white")
     pix = im.load()
     width_sample = im.size[0]//(len(colors)//2)

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -53,10 +53,8 @@ def set_theme(wallpaper, colorscheme, restore=False):
     files.write_script(wallpaper, colorscheme)
     files.change_current(wallpaper)
 
-    Popen(['chmod', '+x', path.join(WPG_DIR, "wp_init.sh")])
-
     if settings.getboolean('execute_cmd', False) and not restore:
-        Popen(['bash', '-c', settings['command']])
+        Popen(settings['command'].split())
 
 
 def delete_theme(filename):

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -1,7 +1,6 @@
 import pywal
 import shutil
 import logging
-from os.path import realpath, basename
 from os import remove, path, symlink
 from subprocess import Popen
 
@@ -14,8 +13,8 @@ from . import reload
 
 def create_theme(filepath):
     """create a colors-scheme from a filepath"""
-    filepath = realpath(filepath)
-    filename = basename(filepath).replace(" ", "_")
+    filepath = path.realpath(filepath)
+    filename = path.basename(filepath).replace(" ", "_")
     tmplink = path.join(WALL_DIR, ".tmp.link")
 
     symlink(filepath, tmplink)
@@ -48,8 +47,8 @@ def set_theme(wallpaper, colorscheme, restore=False):
 
     if set_wall:
         filepath = path.join(WALL_DIR, wallpaper)
-        set_wall = filepath if path.isfile(filepath) else colors["wallpaper"]
-        pywal.wallpaper.change(set_wall)
+        imagepath = filepath if path.isfile(filepath) else colors["wallpaper"]
+        pywal.wallpaper.change(imagepath)
 
     files.write_script(wallpaper, colorscheme)
     files.change_current(wallpaper)
@@ -66,7 +65,7 @@ def delete_theme(filename):
 
 
 def get_current():
-    image = basename(realpath(path.join(WPG_DIR, '.current')))
+    image = path.basename(path.realpath(path.join(WPG_DIR, '.current')))
     return image
 
 
@@ -84,8 +83,8 @@ def reset_theme(theme_name):
 def import_theme(wallpaper, json_file, theme=False):
     """import a colorscheme from a JSON file either in
     terminal.sexy or pywal format"""
-    json_file = realpath(json_file)
-    filename = basename(json_file)
+    json_file = path.realpath(json_file)
+    filename = path.basename(json_file)
 
     if theme:
         theme = pywal.theme.file(filename)

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -39,7 +39,7 @@ def set_theme(wallpaper, colorscheme, restore=False):
 
     if not restore:
         pywal.export.every(colors, FORMAT_DIR)
-        color.apply_colorscheme(colors)
+        color.apply_colorscheme(color.get_color_dict(colors, colorscheme))
         if reload_all:
             reload.all()
     else:

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -4,7 +4,7 @@ import logging
 from os import remove, path, symlink
 from subprocess import Popen
 
-from .config import WPG_DIR, WALL_DIR, FORMAT_DIR, settings
+from .config import WPG_DIR, WALL_DIR, FORMAT_DIR, settings, user_keywords
 from . import color
 from . import files
 from . import sample
@@ -60,6 +60,7 @@ def set_theme(wallpaper, colorscheme, restore=False):
 def delete_theme(filename):
     remove(path.join(WALL_DIR, filename))
     files.delete_colorschemes(filename)
+    user_keywords.remove_section(filename)
 
 
 def get_current():

--- a/wpgtk/gui/color_grid.py
+++ b/wpgtk/gui/color_grid.py
@@ -202,13 +202,6 @@ class ColorGrid(Gtk.Grid):
                 height=300)
         self.sample.set_from_pixbuf(self.pixbuf_sample)
 
-    def update_combo(self, option_list):
-        self.option_combo.set_model(option_list)
-        self.option_combo.set_entry_text_column(0)
-
-    def set_edit_combo(self, x):
-        self.option_combo.set_active(x)
-
     def on_ok_click(self, widget):
         current_walls = files.get_file_list()
         if len(current_walls) > 0:

--- a/wpgtk/gui/keyword_dialog.py
+++ b/wpgtk/gui/keyword_dialog.py
@@ -1,0 +1,29 @@
+from gi import require_version
+from gi.repository import Gtk
+require_version("Gtk", "3.0")
+
+
+class KeywordDialog(Gtk.Dialog):
+
+    def __init__(self, parent):
+        Gtk.Dialog.__init__(self, "Name you keyword/value set", parent, 0,
+                            (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+                             Gtk.STOCK_OK, Gtk.ResponseType.OK))
+
+        self.set_default_size(150, 100)
+        self.name_text_input = Gtk.Entry()
+        self.error_lbl = Gtk.Label()
+
+        box = self.get_content_area()
+        box.set_border_width(10)
+        box.set_spacing(10)
+        box.add(self.name_text_input)
+        box.add(self.error_lbl)
+
+        self.show_all()
+
+    def get_section_name(self):
+        if len(self.name_text_input.get_text()) <= 0:
+            raise Exception('Empty name not allowed')
+
+        return self.name_text_input.get_text()

--- a/wpgtk/gui/keyword_grid.py
+++ b/wpgtk/gui/keyword_grid.py
@@ -1,5 +1,5 @@
-from ..data.config import user_keywords, write_conf
 from ..data import keywords
+from ..data import files
 from gi import require_version
 from gi.repository import Gtk
 require_version("Gtk", "3.0")
@@ -17,20 +17,28 @@ class KeywordGrid(Gtk.Grid):
         self.set_row_spacing(PAD)
         self.set_column_spacing(PAD)
 
+        self.delete_button = Gtk.Button('Remove')
+        self.delete_button.connect('clicked', self.remove_keyword)
+
+        self.add_button = Gtk.Button('Add')
+        self.add_button.connect('clicked', self.append_new_keyword)
+
+        self.selected_file = ""
+        wallpaper_list = Gtk.ListStore(str)
+        for elem in list(files.get_file_list()):
+            wallpaper_list.append([elem])
+
         self.liststore = Gtk.ListStore(str, str)
         self.reload_keyword_list()
 
-        self.save_btn = Gtk.Button('Save')
-        self.save_btn.connect('clicked', self.save_keywords)
-
-        self.del_btn = Gtk.Button('Remove')
-        self.del_btn.connect('clicked', self.remove_keyword)
-
-        self.add_btn = Gtk.Button('Add')
-        self.add_btn.connect('clicked', self.append_new_keyword)
+        self.wallpaper_combo = Gtk.ComboBox.new_with_model(wallpaper_list)
+        self.renderer_text = Gtk.CellRendererText()
+        self.wallpaper_combo.pack_start(self.renderer_text, True)
+        self.wallpaper_combo.add_attribute(self.renderer_text, "text", 0)
+        self.wallpaper_combo.set_entry_text_column(0)
+        self.wallpaper_combo.connect("changed", self.on_wallpaper_change)
 
         self.status_lbl = Gtk.Label('')
-
         self.keyword_tree = Gtk.TreeView(model=self.liststore)
 
         scroll = Gtk.ScrolledWindow()
@@ -38,9 +46,9 @@ class KeywordGrid(Gtk.Grid):
         scroll.set_min_content_height(400)
         scroll.add(self.keyword_tree)
 
-        self.attach(self.add_btn, 0, 0, 2, 1)
-        self.attach(self.save_btn, 0, 1, 1, 1)
-        self.attach(self.del_btn, 1, 1, 1, 1)
+        self.attach(self.wallpaper_combo, 0, 0, 2, 1)
+        self.attach(self.add_button, 0, 1, 1, 1)
+        self.attach(self.delete_button, 1, 1, 1, 1)
         self.attach(scroll, 0, 2, 2, 1)
         self.attach(self.status_lbl, 0, 3, 2, 1)
 
@@ -61,36 +69,53 @@ class KeywordGrid(Gtk.Grid):
     def remove_keyword(self, widget):
         self.status_lbl.set_text('')
         (m, pathlist) = self.keyword_tree.get_selection().get_selected_rows()
+
         for path in pathlist:
             tree_iter = m.get_iter(path)
             value = m.get_value(tree_iter, 0)
-            user_keywords.pop(value, None)
+            keywords.remove_pair(self.selected_file, value)
             self.reload_keyword_list()
 
     def text_edited(self, widget, path, text, col):
         self.status_lbl.set_text('')
         if(col == 0):
             try:
-                keywords.update_key(self.liststore[path][col], text)
+                keywords.update_key(
+                    self.selected_file,
+                    self.liststore[path][col],
+                    text
+                )
             except Exception as e:
                 self.status_lbl.set_text(str(e))
         else:
             try:
-                keywords.update_value(self.liststore[path][0], text)
+                keywords.update_value(
+                    self.selected_file,
+                    self.liststore[path][0],
+                    text
+                )
             except Exception as e:
                 self.status_lbl.set_text(str(e))
         self.reload_keyword_list()
 
     def reload_keyword_list(self):
         self.liststore.clear()
-        for k, v in user_keywords.items():
+        parser = keywords.get_keywords_parser(self.selected_file)
+        for k, v in parser['keywords'].items():
             self.liststore.append([k, v])
 
-    def save_keywords(self, widget):
-        write_conf()
-        self.status_lbl.set_text('Saved')
+    def on_wallpaper_change(self, widget):
+        x = widget.get_active()
+
+        current_walls = files.get_file_list()
+        self.selected_file = current_walls[x]
+        self.reload_keyword_list()
 
     def append_new_keyword(self, widget):
         self.status_lbl.set_text('')
-        keywords.create_pair('keyword' + str(len(self.liststore)), 'value')
+        keywords.create_pair(
+            self.selected_file,
+            'keyword' + str(len(self.liststore)),
+            'value'
+        )
         self.reload_keyword_list()

--- a/wpgtk/gui/keyword_grid.py
+++ b/wpgtk/gui/keyword_grid.py
@@ -1,11 +1,11 @@
 from ..data import keywords
 from ..data import files
+from ..data.config import KEYWORD_DIR
 from gi import require_version
 from gi.repository import Gtk
 require_version("Gtk", "3.0")
 
 PAD = 10
-
 
 class KeywordGrid(Gtk.Grid):
     def __init__(self, parent):
@@ -23,17 +23,26 @@ class KeywordGrid(Gtk.Grid):
         self.add_button = Gtk.Button('Add')
         self.add_button.connect('clicked', self.append_new_keyword)
 
-        self.selected_file = ""
-        self.wallpaper_combo = Gtk.ComboBoxText()
-        self.wallpaper_combo.set_entry_text_column(0)
-        for elem in list(files.get_file_list()):
-            self.wallpaper_combo.append_text(elem)
+        self.reset_button = Gtk.Button('Reset')
+        # self.reset_button.connect('clicked', self.reset_keyword_file)
+
+        self.create_button = Gtk.Button('Create')
+        self.create_button.connect('clicked', self.on_create_click)
+
+        self.selected_file = None
+        self.keyword_file_combo = Gtk.ComboBoxText()
+        self.keyword_file_combo.set_entry_text_column(0)
+        self.keyword_file_combo.append_text('Default')
+        for elem in list(files.get_file_list(KEYWORD_DIR, False)):
+            self.keyword_file_combo.append_text(elem)
+
+        self.keyword_file_combo.set_active(0)
 
         self.liststore = Gtk.ListStore(str, str)
         self.reload_keyword_list()
 
-        self.wallpaper_combo.set_entry_text_column(0)
-        self.wallpaper_combo.connect("changed", self.on_wallpaper_change)
+        self.keyword_file_combo.set_entry_text_column(0)
+        self.keyword_file_combo.connect("changed", self.on_keyword_file_change)
 
         self.status_lbl = Gtk.Label('')
         self.keyword_tree = Gtk.TreeView(model=self.liststore)
@@ -43,11 +52,13 @@ class KeywordGrid(Gtk.Grid):
         scroll.set_min_content_height(400)
         scroll.add(self.keyword_tree)
 
-        self.attach(self.wallpaper_combo, 0, 0, 2, 1)
+        self.attach(self.keyword_file_combo, 0, 0, 2, 1)
+        self.attach(self.create_button, 2, 0, 1, 1)
         self.attach(self.add_button, 0, 1, 1, 1)
         self.attach(self.delete_button, 1, 1, 1, 1)
-        self.attach(scroll, 0, 2, 2, 1)
-        self.attach(self.status_lbl, 0, 3, 2, 1)
+        self.attach(self.reset_button, 2, 1, 1, 1)
+        self.attach(scroll, 0, 2, 3, 1)
+        self.attach(self.status_lbl, 0, 3, 3, 1)
 
         key_renderer = Gtk.CellRendererText()
         key_renderer.set_property('editable', True)
@@ -63,6 +74,23 @@ class KeywordGrid(Gtk.Grid):
         value_text = Gtk.TreeViewColumn("Value", value_renderer, text=1)
         self.keyword_tree.append_column(value_text)
 
+    def on_create_click(self, widget):
+        filechooser = Gtk.FileChooserDialog(
+                      'Create Config File', self.parent,
+                      Gtk.FileChooserAction.SAVE,
+                      (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+                       Gtk.STOCK_OPEN, Gtk.ResponseType.OK))
+        file_filter = Gtk.FileFilter()
+        file_filter.set_name("Conf")
+        file_filter.add_mime_type("text/plain")
+        file_filter.add_pattern("*.conf")
+        filechooser.add_filter(file_filter)
+        filechooser.set_current_folder(KEYWORD_DIR)
+        response = filechooser.run()
+        print(filechooser.get_filename())
+        print(response)
+        filechooser.destroy()
+
     def remove_keyword(self, widget):
         self.status_lbl.set_text('')
         (m, pathlist) = self.keyword_tree.get_selection().get_selected_rows()
@@ -75,34 +103,30 @@ class KeywordGrid(Gtk.Grid):
 
     def text_edited(self, widget, path, text, col):
         self.status_lbl.set_text('')
-        if(col == 0):
+        if (col == 0):
             try:
-                keywords.update_key(
-                    self.liststore[path][col],
-                    text,
-                    self.selected_file
-                )
+                keywords.update_key(self.liststore[path][col], text,
+                                    self.selected_file)
             except Exception as e:
                 self.status_lbl.set_text(str(e))
         else:
             try:
-                keywords.update_value(
-                    self.liststore[path][0],
-                    text,
-                    self.selected_file
-                )
+                keywords.update_value(self.liststore[path][0], text,
+                                      self.selected_file)
             except Exception as e:
                 self.status_lbl.set_text(str(e))
         self.reload_keyword_list()
 
     def reload_keyword_list(self):
         keyword_section = keywords.get_keywords_section(self.selected_file)
+
         self.liststore.clear()
         for k, v in keyword_section.items():
             self.liststore.append([k, v])
 
-    def on_wallpaper_change(self, widget):
-        self.selected_file = widget.get_active_text()
+    def on_keyword_file_change(self, widget):
+        selected_entry = widget.get_active_text()
+        self.selected_file = None if selected_entry == 'Default' else selected_entry
         self.reload_keyword_list()
 
     def append_new_keyword(self, widget):

--- a/wpgtk/gui/template_grid.py
+++ b/wpgtk/gui/template_grid.py
@@ -39,8 +39,8 @@ class TemplateGrid(Gtk.Grid):
         self.button_add.connect('clicked', self.on_add_clicked)
         self.button_rm = Gtk.Button('Remove')
         self.button_rm.connect('clicked', self.on_rm_clicked)
-        self.button_open = Gtk.Button('Edit')
-        self.button_open.connect('clicked', self.on_open_clicked)
+        self.button_edit = Gtk.Button('Edit')
+        self.button_edit.connect('clicked', self.on_open_clicked)
 
         self.liststore = Gtk.ListStore(Pixbuf, str)
         self.file_view = Gtk.IconView.new()
@@ -64,8 +64,8 @@ class TemplateGrid(Gtk.Grid):
             self.liststore.append([pixbuf, filen])
 
         self.grid_edit.attach(self.button_add, 0, 0, 2, 1)
-        self.grid_edit.attach(self.button_rm, 0, 1, 1, 1)
-        self.grid_edit.attach(self.button_open, 1, 1, 1, 1)
+        self.grid_edit.attach(self.button_edit, 0, 1, 1, 1)
+        self.grid_edit.attach(self.button_rm, 1, 1, 1, 1)
         self.grid_edit.attach(self.scroll, 0, 2, 2, 1)
 
         self.attach(self.grid_edit, 0, 0, 1, 1)

--- a/wpgtk/gui/template_grid.py
+++ b/wpgtk/gui/template_grid.py
@@ -55,9 +55,7 @@ class TemplateGrid(Gtk.Grid):
         self.scroll.set_min_content_height(400)
         self.scroll.add(self.file_view)
 
-        self.item_names = [filen for filen in
-                           files.get_file_list(OPT_DIR, False)
-                           if '.base' in filen]
+        self.item_names = files.get_file_list(OPT_DIR, r".*\.base$")
 
         for filen in self.item_names:
             pixbuf = Gtk.IconTheme.get_default().load_icon(icon, 64, 0)
@@ -87,9 +85,7 @@ class TemplateGrid(Gtk.Grid):
         if response == Gtk.ResponseType.OK:
             for f in filechooser.get_filenames():
                 files.add_template(f)
-            self.item_names = [f for f in
-                               files.get_file_list(OPT_DIR, False)
-                               if '.base' in f]
+            self.item_names = files.get_file_list(OPT_DIR, r".*\.base$")
             self.liststore = Gtk.ListStore(Pixbuf, str)
             for filen in self.item_names:
                 pixbuf = Gtk.IconTheme.get_default().load_icon(icon, 64, 0)

--- a/wpgtk/gui/theme_picker.py
+++ b/wpgtk/gui/theme_picker.py
@@ -113,7 +113,6 @@ class mainWindow(Gtk.Window):
             self.option_combo.set_active(current_idx)
             self.colorscheme.set_active(current_idx)
             self.cpage.option_combo.set_active(current_idx)
-            self.keypage.theme_combo.set_active(current_idx + 1)
             self.set_button.set_sensitive(True)
 
     def on_add_clicked(self, widget):
@@ -191,7 +190,6 @@ class mainWindow(Gtk.Window):
     def colorscheme_box_change(self, widget):
         x = self.colorscheme.get_active()
         self.cpage.option_combo.set_active(x)
-        self.keypage.theme_combo.set_active(x + 1)
 
 
 def run(args):

--- a/wpgtk/gui/theme_picker.py
+++ b/wpgtk/gui/theme_picker.py
@@ -113,6 +113,7 @@ class mainWindow(Gtk.Window):
             self.option_combo.set_active(current_idx)
             self.colorscheme.set_active(current_idx)
             self.cpage.option_combo.set_active(current_idx)
+            self.keypage.wallpaper_combo.set_active(current_idx)
             self.set_button.set_sensitive(True)
 
     def on_add_clicked(self, widget):
@@ -132,16 +133,22 @@ class mainWindow(Gtk.Window):
         response = filechooser.run()
 
         if response == Gtk.ResponseType.OK:
+            option_list = Gtk.ListStore(str)
+
             for f in filechooser.get_filenames():
                 themer.create_theme(f)
-            option_list = Gtk.ListStore(str)
+
             for elem in list(files.get_file_list()):
                 option_list.append([elem])
+
             self.option_combo.set_model(option_list)
             self.option_combo.set_entry_text_column(0)
             self.colorscheme.set_model(option_list)
             self.colorscheme.set_entry_text_column(0)
-            self.cpage.update_combo(option_list)
+
+            self.cpage.option_combo.set_model(option_list)
+            self.keypage.wallpaper_combo.set_model(option_list)
+
         filechooser.destroy()
 
     def on_set_clicked(self, widget):
@@ -165,8 +172,9 @@ class mainWindow(Gtk.Window):
             self.option_combo.set_model(option_list)
             self.option_combo.set_entry_text_column(0)
             self.colorscheme.set_model(option_list)
-            self.colorscheme.set_entry_text_column(0)
-            self.cpage.update_combo(option_list)
+
+            self.cpage.option_combo.set_model(option_list)
+            self.keypage.wallpaper_combo.set_model(option_list)
 
     def combo_box_change(self, widget):
         self.set_button.set_sensitive(True)
@@ -185,8 +193,8 @@ class mainWindow(Gtk.Window):
     def colorscheme_box_change(self, widget):
         x = self.colorscheme.get_active()
 
-        # set the ComboBox in color_grid
-        self.cpage.set_edit_combo(x)
+        self.cpage.option_combo.set_active(x)
+        self.keypage.wallpaper_combo.set_active(x)
 
 
 def run(args):

--- a/wpgtk/gui/theme_picker.py
+++ b/wpgtk/gui/theme_picker.py
@@ -113,6 +113,7 @@ class mainWindow(Gtk.Window):
             self.option_combo.set_active(current_idx)
             self.colorscheme.set_active(current_idx)
             self.cpage.option_combo.set_active(current_idx)
+            self.keypage.theme_combo.set_active(current_idx + 1)
             self.set_button.set_sensitive(True)
 
     def on_add_clicked(self, widget):
@@ -190,6 +191,7 @@ class mainWindow(Gtk.Window):
     def colorscheme_box_change(self, widget):
         x = self.colorscheme.get_active()
         self.cpage.option_combo.set_active(x)
+        self.keypage.theme_combo.set_active(x + 1)
 
 
 def run(args):

--- a/wpgtk/gui/theme_picker.py
+++ b/wpgtk/gui/theme_picker.py
@@ -113,7 +113,6 @@ class mainWindow(Gtk.Window):
             self.option_combo.set_active(current_idx)
             self.colorscheme.set_active(current_idx)
             self.cpage.option_combo.set_active(current_idx)
-            self.keypage.wallpaper_combo.set_active(current_idx)
             self.set_button.set_sensitive(True)
 
     def on_add_clicked(self, widget):
@@ -147,7 +146,6 @@ class mainWindow(Gtk.Window):
             self.colorscheme.set_entry_text_column(0)
 
             self.cpage.option_combo.set_model(option_list)
-            self.keypage.wallpaper_combo.set_model(option_list)
 
         filechooser.destroy()
 
@@ -174,7 +172,6 @@ class mainWindow(Gtk.Window):
             self.colorscheme.set_model(option_list)
 
             self.cpage.option_combo.set_model(option_list)
-            self.keypage.wallpaper_combo.set_model(option_list)
 
     def combo_box_change(self, widget):
         self.set_button.set_sensitive(True)
@@ -192,9 +189,7 @@ class mainWindow(Gtk.Window):
 
     def colorscheme_box_change(self, widget):
         x = self.colorscheme.get_active()
-
         self.cpage.option_combo.set_active(x)
-        self.keypage.wallpaper_combo.set_active(x)
 
 
 def run(args):

--- a/wpgtk/gui/theme_picker.py
+++ b/wpgtk/gui/theme_picker.py
@@ -194,7 +194,3 @@ def run(args):
     win.connect('delete-event', Gtk.main_quit)
     win.show_all()
     Gtk.main()
-
-
-if __name__ == '__main__':
-    run()


### PR DESCRIPTION
- [x] Update logic to accept new keyword files where you can define user-defined keywords per file
- [x] Update screen to manipulate keywords on a color-scheme basis
- [x] If there is a missing key on a template file, fail to update the template gracefully
- [x] Cleanup unnecessary or deprecated methods
- [x] If default configuration file has keys that color-scheme keyword file doesn't update the color-scheme keyword file
- [x] replace unnecessary ComboBox usage with ComboBoxText
- [x] handle edge cases

![1610326526](https://user-images.githubusercontent.com/11150153/104140143-87d38f00-5375-11eb-87e4-53bac300b04e.png)
![1610326574](https://user-images.githubusercontent.com/11150153/104140144-886c2580-5375-11eb-8412-9597705eb2f5.png)
