### PR TITLE
Fix bug where Settings section exist, but the gtk-theme-name key does not exist

### DIFF
--- a/wpgtk/data/reload.py
+++ b/wpgtk/data/reload.py
@@ -109,7 +109,7 @@ def gtk3():
         if os.path.isfile(settings_ini):
             gtkrc = configparser.ConfigParser()
             gtkrc.read(settings_ini)
-            theme = gtkrc["Settings"].get("gtk-theme-name") if "Settings" in gtkrc else "FlatColor"
+            theme = gtkrc["Settings"].get("gtk-theme-name", "FlatColor") if "Settings" in gtkrc else "FlatColor"
             xsettingsd(theme)
         else:
             xsettingsd("FlatColor")


### PR DESCRIPTION
Fix bug where Settings section exist, but the gtk-theme-name key does not exist not exist. 

In this edge case theme is set to `None`, which when passed to `xsettingsd()` errors out with a `TypeError` since you cannot concatenate string with NoneType (line 53)

Sample error message:

```
✖ cat ~/.config/gtk-3.0/settings.ini 
[Settings]
gtk-application-prefer-dark-theme=0

➜ wpg -s 4color-kasumi.jpg                  [i] image         Using image 4color-kasumi.jpg.
[i] theme         Set theme to _home_zegheim__config_wpg_wallpapers_4color-kasumi_jpg_dark_wal__1.1.0.json.
[i] colors        Found cached colorscheme.
[i] sequences     Set terminal colors.
[i] export        Exported all files.
[i] export        Exported all user files.
[i] color         wrote: icon-step1
[i] color         wrote: gtk3.20
[i] color         wrote: gtk3.0
[i] color         wrote: gtk2
Traceback (most recent call last):
  File "/home/zegheim/.local/bin/wpg", line 8, in <module>
    sys.exit(main())
  File "/home/zegheim/.local/lib/python3.9/site-packages/wpgtk/__main__.py", line 305, in main
    process_args(args)
  File "/home/zegheim/.local/lib/python3.9/site-packages/wpgtk/__main__.py", line 189, in process_args
    themer.set_theme(args.s[0], args.s[0], args.r)
  File "/home/zegheim/.local/lib/python3.9/site-packages/wpgtk/data/themer.py", line 44, in set_theme
    reload.all()
  File "/home/zegheim/.local/lib/python3.9/site-packages/wpgtk/data/reload.py", line 141, in all
    gtk3()
  File "/home/zegheim/.local/lib/python3.9/site-packages/wpgtk/data/reload.py", line 113, in gtk3
    xsettingsd(theme)
  File "/home/zegheim/.local/lib/python3.9/site-packages/wpgtk/data/reload.py", line 53, in xsettingsd
    tmp.write('Net/ThemeName "' + theme + '"\n')
TypeError: can only concatenate str (not "NoneType") to str
```