### PR TITLE
Restart dunst on reload.

### DIFF
--- a/wpgtk/data/reload.py
+++ b/wpgtk/data/reload.py
@@ -35,7 +35,8 @@ def polybar():
 def dunst():
     """Kills dunst so that notify-send reloads it when called."""
     if shutil.which("dunst") and util.get_pid("dunst"):
-        subprocess.Popen(["killall", "dunst"])
+        subprocess.Popen(["killall", "-w", "dunst"])
+        subprocess.Popen(["dunst"])
 
 
 def openbox():


### PR DESCRIPTION
Fixes #158 .

Since it seems you are busy, I have fixed the dunst reload issue. I have been using this version on Arch for a long time now without any problems.

This does mean that any dunst instances running from a custom configuration file will not be reloaded properly. Until the dunst maintainers add the option to send a signal to reload, this is the best we can do.