### PR TITLE
Add setting to use pywal Skip changing colors in terminals

### DIFF
--- a/wpgtk/__main__.py
+++ b/wpgtk/__main__.py
@@ -123,8 +123,13 @@ def read_args(args):
                         action="store_true")
 
     parser.add_argument("--noreload",
-                        help="Skip reloading other software after"
+                        help="Skip reloading other software after "
                         "applying colorscheme",
+                        action="store_true")
+
+    parser.add_argument("--noterminal",
+                        help="Skip changing the terminal colorscheme "
+                        "using pywal Skip changing colors in terminals",
                         action="store_true")
 
     return parser.parse_args()
@@ -155,6 +160,9 @@ def process_arg_errors(args):
 def process_args(args):
     if args.light:
         settings["light_theme"] = "true"
+
+    if args.noterminal:
+        settings["terminal"] = "false"
 
     if args.n:
         settings["set_wallpaper"] = "false"

--- a/wpgtk/data/themer.py
+++ b/wpgtk/data/themer.py
@@ -33,9 +33,10 @@ def set_theme(wallpaper, colorscheme, restore=False):
     target = colorscheme if is_file else path.join(WALL_DIR, colorscheme)
 
     set_wall = settings.getboolean("set_wallpaper", True)
+    set_term = settings.getboolean("terminal", True)
     reload_all = settings.getboolean("reload", True)
     colors = color.get_pywal_dict(target, is_file)
-    pywal.sequences.send(colors, WPG_DIR, vte_fix=use_vte)
+    pywal.sequences.send(colors, WPG_DIR, to_send=set_term, vte_fix=use_vte)
 
     if not restore:
         pywal.export.every(colors, FORMAT_DIR)

--- a/wpgtk/gui/option_grid.py
+++ b/wpgtk/gui/option_grid.py
@@ -105,6 +105,14 @@ class OptionsGrid(Gtk.Grid):
         )
         self.lbl_reload = Gtk.Label("Reload other software")
 
+        self.terminal_switch = Gtk.Switch()
+        self.terminal_switch.connect(
+            "notify::active",
+            self.on_activate,
+            "terminal"
+        )
+        self.lbl_terminal = Gtk.Label("Change terminal colors")
+
         # edit cmd
         self.editor_lbl = Gtk.Label("Open optional files with:")
         self.editor_txt = Gtk.Entry()
@@ -153,6 +161,9 @@ class OptionsGrid(Gtk.Grid):
 
         self.switch_grid.attach(self.lbl_reload, 5, 4, 3, 1)
         self.switch_grid.attach(self.reload_switch, 9, 4, 1, 1)
+
+        self.switch_grid.attach(self.lbl_terminal, 1, 5, 3, 1)
+        self.switch_grid.attach(self.terminal_switch, 4, 5, 1, 1)
 
         # Active Grid attach
         self.active_grid.attach(self.backend_lbl, 1, 1, 1, 1)
@@ -205,6 +216,8 @@ class OptionsGrid(Gtk.Grid):
             .set_active(settings.getboolean("auto_adjust", False))
         self.reload_switch\
             .set_active(settings.getboolean("reload", True))
+        self.terminal_switch\
+            .set_active(settings.getboolean("terminal", True))
 
         self.editor_txt\
             .set_text(settings.get("editor", "urxvt -e vim"))

--- a/wpgtk/misc/wpg.conf
+++ b/wpgtk/misc/wpg.conf
@@ -11,5 +11,6 @@ alpha = 100
 smart_sort = true
 auto_adjust = false
 reload = true
+terminal = true
 
 [keywords]


### PR DESCRIPTION
Pywal has an option to skip setting the terminal colors.
It accepts a boolean option in the pywal.sequence.send function

This PR adds that as a CLI flag --noterminal and also as a wpg.conf setting