### PR TITLE
fix crash when dealing with gif wallpapers

### DIFF
--- a/wpgtk/gui/theme_picker.py
+++ b/wpgtk/gui/theme_picker.py
@@ -197,7 +197,7 @@ class mainWindow(Gtk.Window):
         selected_file = files.get_file_list()[x]
         filepath = os.path.join(WALL_DIR, selected_file)
 
-        #if re have a gif
+        #if we have a gif
         if (pathlib.Path(filepath).suffix == '.gif'):
             self.pixbuf_preview = GdkPixbuf.PixbufAnimation.new_from_file(filepath)
             self.pixbuf_preview = GdkPixbuf.PixbufAnimation.get_static_image(self.pixbuf_preview)

--- a/wpgtk/gui/theme_picker.py
+++ b/wpgtk/gui/theme_picker.py
@@ -32,7 +32,6 @@ class mainWindow(Gtk.Window):
         file_name = themer.get_current()
         logging.info('current wallpaper: ' + file_name)
         sample_name = files.get_sample_path(file_name)
-
         self.notebook = Gtk.Notebook()
         self.add(self.notebook)
 
@@ -61,7 +60,6 @@ class mainWindow(Gtk.Window):
                 current_idx = i
 
             option_list.append([elem])
-
         self.option_combo = Gtk.ComboBox.new_with_model(option_list)
         self.renderer_text = Gtk.CellRendererText()
         self.option_combo.pack_start(self.renderer_text, True)
@@ -78,33 +76,8 @@ class mainWindow(Gtk.Window):
         self.set_border_width(10)
         self.preview = Gtk.Image()
         self.sample = Gtk.Image()
-
-        if(os.path.isfile(image_name) and os.path.isfile(sample_name)):
-            
-            #if we have a gif
-            if (pathlib.Path(image_name).suffix == '.gif'):
-
-                self.pixbuf_preview = GdkPixbuf.PixbufAnimation.new_from_file(image_name)
-                self.pixbuf_preview = GdkPixbuf.PixbufAnimation.get_static_image(self.pixbuf_preview)
-                self.pixbuf_preview = GdkPixbuf.Pixbuf.scale_simple(self.pixbuf_preview,500,333,GdkPixbuf.InterpType.NEAREST)
-
-                self.pixbuf_sample = GdkPixbuf.PixbufAnimation.new_from_file(sample_name)
-                self.pixbuf_sample = GdkPixbuf.PixbufAnimation.get_static_image(self.pixbuf_sample)
-                self.pixbuf_sample= GdkPixbuf.Pixbuf.scale_simple(self.pixbuf_sample,500,333,GdkPixbuf.InterpType.NEAREST)
-
-                self.preview.set_from_pixbuf(self.pixbuf_preview)
-                self.sample.set_from_pixbuf(self.pixbuf_sample)
-            else :
-                self.pixbuf_preview = GdkPixbuf.Pixbuf.new_from_file_at_scale(
-                                      image_name,
-                                      width=500,
-                                      height=333, preserve_aspect_ratio=False)
-                self.pixbuf_sample = GdkPixbuf.Pixbuf.new_from_file_at_size(
-                                     sample_name,
-                                     width=500, height=500)
-                self.preview.set_from_pixbuf(self.pixbuf_preview)
-                self.sample.set_from_pixbuf(self.pixbuf_sample)
-            
+        
+        self.get_image_preview( image_name, sample_name)
 
         self.add_button = Gtk.Button(label='Add')
         self.set_button = Gtk.Button(label='Set')
@@ -197,24 +170,48 @@ class mainWindow(Gtk.Window):
         selected_file = files.get_file_list()[x]
         filepath = os.path.join(WALL_DIR, selected_file)
 
-        #if we have a gif
+        self.set_image_preview(filepath)
+        
+    def colorscheme_box_change(self, widget):
+        x = self.colorscheme.get_active()
+        self.cpage.option_combo.set_active(x)
+
+    # called on opening to looad the current image
+    def  get_image_preview(self, image_name, sample_name):
+        if(os.path.isfile(image_name) and os.path.isfile(sample_name)):
+            if (pathlib.Path(image_name).suffix == '.gif'):
+
+                self.pixbuf_preview = GdkPixbuf.PixbufAnimation.new_from_file(image_name)
+                self.pixbuf_preview = GdkPixbuf.PixbufAnimation.get_static_image(self.pixbuf_preview)
+                self.pixbuf_preview = GdkPixbuf.Pixbuf.scale_simple(self.pixbuf_preview,500,333,GdkPixbuf.InterpType.NEAREST)
+
+                self.pixbuf_sample = GdkPixbuf.PixbufAnimation.new_from_file(sample_name)
+                self.pixbuf_sample = GdkPixbuf.PixbufAnimation.get_static_image(self.pixbuf_sample)
+                self.pixbuf_sample= GdkPixbuf.Pixbuf.scale_simple(self.pixbuf_sample,500,333,GdkPixbuf.InterpType.NEAREST)
+            else :
+                self.pixbuf_preview = GdkPixbuf.Pixbuf.new_from_file_at_scale(
+                                      image_name,
+                                      width=500,
+                                      height=333, preserve_aspect_ratio=False)
+                self.pixbuf_sample = GdkPixbuf.Pixbuf.new_from_file_at_size(
+                                     sample_name,
+                                     width=500, height=500)
+            self.preview.set_from_pixbuf(self.pixbuf_preview)
+            self.sample.set_from_pixbuf(self.pixbuf_sample)
+            
+    #called when combo box changes the selected image
+    def set_image_preview(self,filepath):
         if (pathlib.Path(filepath).suffix == '.gif'):
             self.pixbuf_preview = GdkPixbuf.PixbufAnimation.new_from_file(filepath)
             self.pixbuf_preview = GdkPixbuf.PixbufAnimation.get_static_image(self.pixbuf_preview)
             self.pixbuf_preview = GdkPixbuf.Pixbuf.scale_simple(self.pixbuf_preview,500,333,GdkPixbuf.InterpType.NEAREST)
-            self.preview.set_from_pixbuf(self.pixbuf_preview)
         else :
             self.pixbuf_preview = GdkPixbuf.Pixbuf.new_from_file_at_scale(
                 str(filepath),
                 width=500,
                 height=333,
                 preserve_aspect_ratio=False)
-            self.preview.set_from_pixbuf(self.pixbuf_preview)
-
-    def colorscheme_box_change(self, widget):
-        x = self.colorscheme.get_active()
-        self.cpage.option_combo.set_active(x)
-
+        self.preview.set_from_pixbuf(self.pixbuf_preview)
 
 def run(args):
     win = mainWindow(args)

--- a/wpgtk/gui/theme_picker.py
+++ b/wpgtk/gui/theme_picker.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pathlib
 
 from . import color_grid
 from . import template_grid
@@ -79,15 +80,31 @@ class mainWindow(Gtk.Window):
         self.sample = Gtk.Image()
 
         if(os.path.isfile(image_name) and os.path.isfile(sample_name)):
-            self.pixbuf_preview = GdkPixbuf.Pixbuf.new_from_file_at_scale(
-                                  image_name,
-                                  width=500,
-                                  height=333, preserve_aspect_ratio=False)
-            self.pixbuf_sample = GdkPixbuf.Pixbuf.new_from_file_at_size(
-                                 sample_name,
-                                 width=500, height=500)
-            self.preview.set_from_pixbuf(self.pixbuf_preview)
-            self.sample.set_from_pixbuf(self.pixbuf_sample)
+            
+            #if we have a gif
+            if (pathlib.Path(image_name).suffix == '.gif'):
+
+                self.pixbuf_preview = GdkPixbuf.PixbufAnimation.new_from_file(image_name)
+                self.pixbuf_preview = GdkPixbuf.PixbufAnimation.get_static_image(self.pixbuf_preview)
+                self.pixbuf_preview = GdkPixbuf.Pixbuf.scale_simple(self.pixbuf_preview,500,333,GdkPixbuf.InterpType.NEAREST)
+
+                self.pixbuf_sample = GdkPixbuf.PixbufAnimation.new_from_file(sample_name)
+                self.pixbuf_sample = GdkPixbuf.PixbufAnimation.get_static_image(self.pixbuf_sample)
+                self.pixbuf_sample= GdkPixbuf.Pixbuf.scale_simple(self.pixbuf_sample,500,333,GdkPixbuf.InterpType.NEAREST)
+
+                self.preview.set_from_pixbuf(self.pixbuf_preview)
+                self.sample.set_from_pixbuf(self.pixbuf_sample)
+            else :
+                self.pixbuf_preview = GdkPixbuf.Pixbuf.new_from_file_at_scale(
+                                      image_name,
+                                      width=500,
+                                      height=333, preserve_aspect_ratio=False)
+                self.pixbuf_sample = GdkPixbuf.Pixbuf.new_from_file_at_size(
+                                     sample_name,
+                                     width=500, height=500)
+                self.preview.set_from_pixbuf(self.pixbuf_preview)
+                self.sample.set_from_pixbuf(self.pixbuf_sample)
+            
 
         self.add_button = Gtk.Button(label='Add')
         self.set_button = Gtk.Button(label='Set')
@@ -180,12 +197,19 @@ class mainWindow(Gtk.Window):
         selected_file = files.get_file_list()[x]
         filepath = os.path.join(WALL_DIR, selected_file)
 
-        self.pixbuf_preview = GdkPixbuf.Pixbuf.new_from_file_at_scale(
-            str(filepath),
-            width=500,
-            height=333,
-            preserve_aspect_ratio=False)
-        self.preview.set_from_pixbuf(self.pixbuf_preview)
+        #if re have a gif
+        if (pathlib.Path(filepath).suffix == '.gif'):
+            self.pixbuf_preview = GdkPixbuf.PixbufAnimation.new_from_file(filepath)
+            self.pixbuf_preview = GdkPixbuf.PixbufAnimation.get_static_image(self.pixbuf_preview)
+            self.pixbuf_preview = GdkPixbuf.Pixbuf.scale_simple(self.pixbuf_preview,500,333,GdkPixbuf.InterpType.NEAREST)
+            self.preview.set_from_pixbuf(self.pixbuf_preview)
+        else :
+            self.pixbuf_preview = GdkPixbuf.Pixbuf.new_from_file_at_scale(
+                str(filepath),
+                width=500,
+                height=333,
+                preserve_aspect_ratio=False)
+            self.preview.set_from_pixbuf(self.pixbuf_preview)
 
     def colorscheme_box_change(self, widget):
         x = self.colorscheme.get_active()
@@ -197,3 +221,4 @@ def run(args):
     win.connect('delete-event', Gtk.main_quit)
     win.show_all()
     Gtk.main()
+    


### PR DESCRIPTION
### Problems: 
* wpgtk crashes on launch after having selected a gif as a wallpaper.
* wpgtk does not update the wallpaper preview properly if it is a gif (happens if you launch it with a normal wallpaper selected and then try to select a gif wallpaper).

#### Program Output:
```
[i] theme_picker  current wallpaper: GiantSkeletonCleanSpriting2_small.gif
Traceback (most recent call last):
  File "/usr/bin/wpg", line 33, in <module>
    sys.exit(load_entry_point('wpgtk==6.5.5', 'console_scripts', 'wpg')())
  File "/usr/lib/python3.10/site-packages/wpgtk/__main__.py", line 309, in main
    _gui.run(args)
  File "/usr/lib/python3.10/site-packages/wpgtk/gui/theme_picker.py", line 196, in run
    win = mainWindow(args)
  File "/usr/lib/python3.10/site-packages/wpgtk/gui/theme_picker.py", line 82, in __init__
    self.pixbuf_preview = GdkPixbuf.Pixbuf.new_from_file_at_scale(
gi.repository.GLib.GError: gdk-pixbuf-error-quark: Nem todos os quadros da imagem GIF foram carregados. (6)

````
Part of the error is in Portuguese, the translation of "Nem todos os quadros da imagem GIF foram carregados. (6)"  would be   "Not all frames of the GIF image were loaded (6) "

Steps to reproduce : 
* add gif image to wpgtk using thunar's search
* set theme with the gif as the wallpaper
* close wpgtk
* should crash next time you open it.

#### Fix suggestion:
Check if the file extension is '.gif' and get a static image from the gif for the preview.

