### PR TITLE
Fixing data types mismatch

### DIFF
--- a/wpgtk/data/files.py
+++ b/wpgtk/data/files.py
@@ -20,7 +20,7 @@ def __check_is_pywal16cols():
     """
     Check if user install pywal16cols or just pywal.
     """
-    pywal_archived_version = [3, 3, 0]  # 3.3.0 was released in 2019
+    pywal_archived_version = [('3', '3', '0')]  # 3.3.0 was released in 2019
     wal_backend_version = get_pywal_version()
 
     # since pywal is archived we can just check the versions


### PR DESCRIPTION
fixing the `"TypeError: '>' not supported between instances of 'tuple' and 'int'"` error while checking `"if wal_backend_version[i] > pywal_archived_version[i]"` by changing pywal_archived_version to tuple.